### PR TITLE
Add github-oidc module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ On the other hand, we hope this repository can be useful as part of our efforts 
 
 A few of our modules are intended to be used directly by end-users, rather than being building blocks for other tools.
 
+* `github-oidc`: A module to create the AWS IAM OpenID Connect provider for GitHub Actions.
 * `tfstate-aws-backend`: A module to create a Terraform state bucket in AWS.
 
 ### Building Block Modules

--- a/modules/github-oidc/README.md
+++ b/modules/github-oidc/README.md
@@ -7,6 +7,11 @@ This module is intended as a small bootstrap primitive. Most accounts need
 exactly one GitHub OIDC provider, which can then be referenced by one or more
 IAM roles with repository- or workflow-specific trust policies.
 
+Because this module currently keeps the AWS provider pinned to `~> 4.0`, it
+includes GitHub OIDC thumbprints explicitly for provider compatibility. Newer
+AWS provider versions allow this argument to be omitted for GitHub's issuer,
+which is AWS's preferred modern behavior.
+
 ## Requirements
 
 - Terraform or OpenTofu
@@ -46,6 +51,11 @@ module "github_oidc" {
 After creation, pass `module.github_oidc.github_oidc_provider_arn` into
 downstream modules or IAM role definitions that trust GitHub Actions.
 
+The module currently configures these GitHub thumbprints:
+
+- `6938fd4d98bab03faadb97b34396831e3780aea1`
+- `1c58a3a8518e8759bf075b76b750d4f2df264fcd`
+
 ## Security Notes
 
 - This module creates only the identity provider.
@@ -54,3 +64,6 @@ downstream modules or IAM role definitions that trust GitHub Actions.
   branches, environments, or workflows can assume the role.
 - The provider uses GitHub's standard issuer URL and `sts.amazonaws.com`
   audience for `aws-actions/configure-aws-credentials`.
+- The configured thumbprints are a compatibility requirement for the provider
+  version this module currently supports, not the preferred long-term AWS
+  configuration model.

--- a/modules/github-oidc/README.md
+++ b/modules/github-oidc/README.md
@@ -1,0 +1,56 @@
+# github-oidc
+
+Creates the AWS IAM OpenID Connect provider used by GitHub Actions for OIDC
+federation into an AWS account.
+
+This module is intended as a small bootstrap primitive. Most accounts need
+exactly one GitHub OIDC provider, which can then be referenced by one or more
+IAM roles with repository- or workflow-specific trust policies.
+
+## Requirements
+
+- Terraform or OpenTofu
+- AWS provider `~> 4.0`
+
+## Inputs
+
+This module has no inputs.
+
+## Outputs
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `github_oidc_provider_arn` | `string` | ARN of the GitHub Actions OIDC provider |
+
+## Usage
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  # Configure the AWS provider for the target account.
+}
+
+module "github_oidc" {
+  source = "github.com/omsf-eco-infra/eco-infra-infra//modules/github-oidc"
+}
+```
+
+After creation, pass `module.github_oidc.github_oidc_provider_arn` into
+downstream modules or IAM role definitions that trust GitHub Actions.
+
+## Security Notes
+
+- This module creates only the identity provider.
+- Downstream IAM roles should still restrict GitHub OIDC claims such as
+  `token.actions.githubusercontent.com:sub` so only intended repositories,
+  branches, environments, or workflows can assume the role.
+- The provider uses GitHub's standard issuer URL and `sts.amazonaws.com`
+  audience for `aws-actions/configure-aws-credentials`.

--- a/modules/github-oidc/main.tf
+++ b/modules/github-oidc/main.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+}

--- a/modules/github-oidc/main.tf
+++ b/modules/github-oidc/main.tf
@@ -2,6 +2,10 @@ resource "aws_iam_openid_connect_provider" "github" {
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   # TODO: Remove thumbprint_list when this module can require a newer AWS
   # provider version that supports omitting it for GitHub OIDC.
   thumbprint_list = [

--- a/modules/github-oidc/main.tf
+++ b/modules/github-oidc/main.tf
@@ -1,4 +1,11 @@
 resource "aws_iam_openid_connect_provider" "github" {
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
+
+  # TODO: Remove thumbprint_list when this module can require a newer AWS
+  # provider version that supports omitting it for GitHub OIDC.
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
 }

--- a/modules/github-oidc/outputs.tf
+++ b/modules/github-oidc/outputs.tf
@@ -1,0 +1,4 @@
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider in IAM."
+  value       = aws_iam_openid_connect_provider.github.arn
+}

--- a/modules/github-oidc/providers.tf
+++ b/modules/github-oidc/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
This will add in a simple module for a GitHub OIDC Identity Provider. This should be created once per account, and its output might be the input to several other modules we develop (for example, one might have several `lambdacron` variants, each representing a different GitHub repository that uses OIDC to allow a workflow to assume a role -- the ARN from this should be the input for the OIDC IdP for those, rather than having different stacks all try to manage this resource).

To-do:

- [ ] ~Test that this does work without fingerprints (this is new to me, but it looks like fingerprints for the GitHub-AWS connection can be managed automatically -- previously I always hard-coded those into modules)~ UPDATE: fingerprints needed for older providers. One of these days I'll update my machine and stop holding everyone back...

Assisted-by: Codex.app:GPT-5.4