### PR TITLE
GitHub Actions Role and Bootstrap Testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,86 @@
+name: Tofu Tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/tests.yaml"
+      - "bootstrap/**"
+      - "deploy-permissions/**"
+      - "modules/**"
+  push:
+    paths:
+      - ".github/workflows/tests.yaml"
+      - "bootstrap/**"
+      - "deploy-permissions/**"
+      - "modules/**"
+  workflow_dispatch:
+
+env:
+  TF_INPUT: "0"
+  TF_IN_AUTOMATION: "true"
+
+jobs:
+  tofu-tests:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ matrix.working_directory }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: bootstrap
+            working_directory: bootstrap
+          - name: github-actions-aws-role
+            working_directory: modules/internal/github-actions-aws-role
+          - name: repo-oidc-customization
+            working_directory: modules/internal/repo-oidc-customization
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
+
+      - name: Initialize module
+        env:
+          TF_DATA_DIR: ${{ runner.temp }}/${{ matrix.name }}
+        run: tofu init -backend=false -no-color
+
+      - name: Run module tests
+        env:
+          TF_DATA_DIR: ${{ runner.temp }}/${{ matrix.name }}
+        run: tofu test -no-color
+
+  aws-oidc-smoke:
+    needs: tofu-tests
+    if: >-
+      success() && (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+      )
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_TEST_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: eco-infra-infra-tests-${{ github.run_id }}
+
+      - name: Verify assumed role
+        run: aws sts get-caller-identity

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Local .terraform directories
 **/.terraform/*
+**/.terraform.lock.hcl
+!bootstrap/.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # eco-infra-infra
+<<<<<<< Updated upstream
 Infrastructure as Code for the Eco-Infra team
+=======
+
+*Infrastructure modules by OMSF's Ecosystem Infrastructure team.*
+
+In the course of our work building out various cloud-based tools for OMSF and beyond, we have found ourselves repeating a number of patterns in our infrastructure code.
+This repository is an attempt to capture those patterns in reusable modules.
+One one hand, this is a standard "don't repeat yourself" effort, intended to reduce our maintenance burden by centralizing common code in one place.
+On the other hand, we hope this repository can be useful as part of our efforts to teach infrastructure as code to other OMSF developers, by providing examples of what simple reusable components look like.
+
+## Structure
+
+* `modules/`: This directory contains the reusable modules themselves.
+
+## Modules
+
+### End-User Modules
+
+A few of our modules are intended to be used directly by end-users, rather than being building blocks for other tools.
+
+* `github-oidc`: A module to create the AWS IAM OpenID Connect provider for GitHub Actions.
+* `tfstate-aws-backend`: A module to create a Terraform state bucket in AWS.
+
+### Building Block Modules
+
+These modules are intended to be used as building blocks for other tools, and are likely to be reused across many projects.
+
+* `internal/github-actions-aws-role`: A workflow-scoped AWS IAM role for GitHub Actions, with caller-provided policies.
+* `internal/repo-oidc-customization`: Repository-wide GitHub OIDC subject customization coordinated across all of a repository's AWS roles.
+>>>>>>> Stashed changes

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
+    "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
+    "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
+    "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",
+    "zh:91a11c67abe7e3329e86547babc9e56caee23e95beb0438165e8fc7e4f02ae44",
+    "zh:b1b59c5e5076877eb2d5b7cae8629ab3e030ec7972757d4e8a49a20b17131e06",
+    "zh:c3cf2f633400c43b0811c9facedbd56f700a637af7d72144a72422c0b635bb2e",
+    "zh:cfd13d1312127a9326c63126eb637a28dae3249dd67a5bbc52e336fb3e08b259",
+    "zh:dc49d6b634cdfbf6ae796b19b9c781599ab0bc941e2c229a452c76fbc9eee3cc",
+    "zh:e2d1bb7c0f66021039724640897bc7b12eb40eff37e0b94015abb6c41e612219",
+    "zh:ff1c838fb5a695191ff1682db31f7c68b2f7ebeb8d512bf1f0865949728a0b3d",
+  ]
+}
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.13.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:Mug81HyUTKKMngXMOtBxuQ8ge3dVnzt9tGcF9SxLcVE=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -21,7 +21,7 @@ provider "registry.opentofu.org/hashicorp/aws" {
 
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.13.0"
-  constraints = ">= 5.0.0"
+  constraints = ">= 6.0"
   hashes = [
     "h1:Mug81HyUTKKMngXMOtBxuQ8ge3dVnzt9tGcF9SxLcVE=",
     "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -7,6 +7,8 @@ The role module owns OIDC provider discovery and role-secret publication;
 bootstrap supplies repository-specific defaults and continues to own the
 region secret.
 
+This is intended to provide the infrastructure that allows us to run live tests of the repository's reusable modules. It is not intended to be reused by end users (unless you are setting it up for a fork of this repo).
+
 ## Account architecture
 
 The `eco-infra-infra-tests` role belongs in the root AWS account. GitHub

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -3,6 +3,9 @@
 This root module creates the permissionless AWS IAM role assumed by the
 repository's tests workflow, configures the repository's GitHub OIDC subject
 template, and publishes the role ARN and AWS region as GitHub Actions secrets.
+The role module owns OIDC provider discovery and role-secret publication;
+bootstrap supplies repository-specific defaults and continues to own the
+region secret.
 
 ## Account architecture
 
@@ -83,7 +86,9 @@ tofu -chdir=bootstrap apply /tmp/eco-infra-infra-bootstrap.tfplan
 ```
 
 Override `github_repository` during the plan if applying this bootstrap to a
-repository other than `omsf-eco-infra/eco-infra-infra`.
+repository other than `omsf-eco-infra/eco-infra-infra`. Override `role_name` or
+`role_secret_name` to replace the defaults `eco-infra-infra-tests` and
+`AWS_GHA_TEST_ROLE_ARN`.
 
 The AWS credentials used for the apply must be able to read the account OIDC
 provider and manage the test IAM role. Configure the GitHub provider with a

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -72,13 +72,13 @@ aws sts get-caller-identity
 export GITHUB_TOKEN=<github-token>
 ```
 
-The S3 backend is intentionally configured at initialization time so account
-and state-location details are not committed to the repository:
+The S3 backend has defaults in `bootstrap/providers.tf`, but you can override the
+bucket/key/region at initialization time:
 
 ```console
 tofu -chdir=bootstrap init \
   -backend-config="bucket=<state-bucket>" \
-  -backend-config="key=eco-infra-infra/bootstrap/terraform.tfstate" \
+  -backend-config="key=eco-infra-infra-tests/bootstrap/terraform.tfstate" \
   -backend-config="region=us-east-1" \
   -backend-config="use_lockfile=true"
 tofu -chdir=bootstrap plan -out=/tmp/eco-infra-infra-bootstrap.tfplan

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,129 @@
+# Test infrastructure bootstrap
+
+This root module creates the permissionless AWS IAM role assumed by the
+repository's tests workflow, configures the repository's GitHub OIDC subject
+template, and publishes the role ARN and AWS region as GitHub Actions secrets.
+
+## Account architecture
+
+The `eco-infra-infra-tests` role belongs in the root AWS account. GitHub
+Actions assumes this role directly through OIDC, making it the workflow's
+initial AWS identity and the trust anchor for the test infrastructure.
+
+For now, this bootstrap creates only that root-account OIDC role. The role is
+intentionally permissionless, so the current workflow can verify OIDC role
+assumption but cannot deploy AWS resources.
+
+Future live tests will use a two-account design:
+
+1. The workflow will assume `eco-infra-infra-tests` through GitHub OIDC in the
+   root account.
+2. OpenTofu's S3 backend will use that root-account identity to read, write,
+   and lock test state in a root-account state bucket.
+3. The AWS provider will use the root role to assume a separate deployment role
+   in the sandbox account.
+4. The sandbox deployment role will receive the generated permissions needed
+   to create and destroy test resources in the sandbox account.
+
+The S3 backend and AWS provider authenticate independently. Live test roots
+will therefore configure the backend to use the workflow's ambient root-role
+credentials while configuring the AWS provider with an `assume_role` block for
+the sandbox deployment role. The sandbox role will not need access to the root
+state bucket.
+
+When live tests are introduced, this bootstrap is expected to grow to:
+
+- create the sandbox deployment role;
+- allow only `eco-infra-infra-tests` to assume that role;
+- grant the root role access to the test-state bucket and permission to assume
+  the exact sandbox role; and
+- attach narrowly scoped policies from `deploy-permissions/` to the sandbox
+  role for the resources under test.
+
+The existing `deploy-permissions/tfstate-aws-backend` module manages permissions
+for deploying the bucket itself; it does not provide the runtime S3 object
+permissions required to use that bucket as an OpenTofu backend.
+
+The account-wide GitHub Actions OIDC provider must already exist. Set
+`github_oidc_provider_arn` to use a specific provider, or omit it to look up the
+provider at `https://token.actions.githubusercontent.com`. If lookup fails,
+confirm that the provider exists in the AWS account selected by your current
+credentials.
+
+## Bootstrap locally
+
+Before applying, confirm that:
+
+- your AWS credentials select the root account where the test role should live;
+- an S3 bucket for the bootstrap state already exists in that account;
+- the account-wide GitHub Actions OIDC provider already exists;
+- the repository does not have another OIDC role that would be broken by
+  changing its repository-wide subject template; and
+- `GITHUB_TOKEN` contains a GitHub token that can manage Actions secrets and
+  the repository OIDC customization.
+
+Check the selected AWS account before initializing:
+
+```console
+aws sts get-caller-identity
+export GITHUB_TOKEN=<github-token>
+```
+
+The S3 backend is intentionally configured at initialization time so account
+and state-location details are not committed to the repository:
+
+```console
+tofu -chdir=bootstrap init \
+  -backend-config="bucket=<state-bucket>" \
+  -backend-config="key=eco-infra-infra/bootstrap/terraform.tfstate" \
+  -backend-config="region=us-east-1" \
+  -backend-config="use_lockfile=true"
+tofu -chdir=bootstrap plan -out=/tmp/eco-infra-infra-bootstrap.tfplan
+tofu -chdir=bootstrap apply /tmp/eco-infra-infra-bootstrap.tfplan
+```
+
+Override `github_repository` during the plan if applying this bootstrap to a
+repository other than `omsf-eco-infra/eco-infra-infra`.
+
+The AWS credentials used for the apply must be able to read the account OIDC
+provider and manage the test IAM role. Configure the GitHub provider with a
+token that can manage Actions secrets and the repository OIDC customization,
+for example through the `GITHUB_TOKEN` environment variable.
+
+The test role intentionally has no workload permissions. Add permissions from
+the matching modules under `deploy-permissions/` only when a CI test begins
+creating and destroying a narrowly scoped AWS fixture.
+
+## Enable the tests workflow
+
+The initial workflow deliberately runs only these complete, mocked contract
+test suites:
+
+- `bootstrap`;
+- `modules/internal/github-actions-aws-role`;
+- `modules/internal/repo-oidc-customization`.
+
+These test groups validate the bootstrap, each internal module, and the
+contract between the two internal modules. None of these contract tests call
+AWS or GitHub. After they pass, the `aws-oidc-smoke` job uses the secrets
+created by this bootstrap and calls `aws sts get-caller-identity` with the real
+OIDC role.
+
+Before pushing the workflow, add the following source and test files to the
+commit:
+
+- `.github/workflows/tests.yaml`;
+- all source files under `bootstrap/`, including `main.tftest.hcl` and the
+  bootstrap dependency lock file;
+- `modules/internal/github-actions-aws-role/main.tftest.hcl`;
+- the two `.tftest.hcl` files and `tests/integration/` under
+  `modules/internal/repo-oidc-customization`.
+
+Do not add `.terraform/`, `.tfdata-test/`, editor swap files, state files, or
+generated provider binaries. Lock files created while testing reusable modules
+are not required; the bootstrap lock file is retained because `bootstrap/` is a
+root configuration.
+
+Pushes run the mocked contract tests. The live OIDC smoke job runs on pushes to
+`main`, manual runs on `main`, and same-repository pull requests. Pull requests
+from forks skip the complete job chain.

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,27 +1,14 @@
 locals {
-  github_oidc_provider_url = "https://token.actions.githubusercontent.com"
-  github_repository_name   = split("/", var.github_repository)[1]
-  test_role_name           = "eco-infra-infra-tests"
-}
-
-data "aws_iam_openid_connect_provider" "github" {
-  arn = var.github_oidc_provider_arn
-  url = var.github_oidc_provider_arn == null ? local.github_oidc_provider_url : null
-
-  lifecycle {
-    postcondition {
-      condition     = contains(self.client_id_list, "sts.amazonaws.com")
-      error_message = "The GitHub OIDC provider must include sts.amazonaws.com in its client ID list."
-    }
-  }
+  github_repository_name = split("/", var.github_repository)[1]
 }
 
 module "test_role" {
   source = "../modules/internal/github-actions-aws-role"
 
-  role_name                = local.test_role_name
+  role_name                = var.role_name
+  role_secret_name         = var.role_secret_name
   role_description         = "Role assumed by the eco-infra-infra tests workflow."
-  github_oidc_provider_arn = data.aws_iam_openid_connect_provider.github.arn
+  github_oidc_provider_arn = var.github_oidc_provider_arn
   github_repository        = var.github_repository
 
   trusted_workflows = [
@@ -49,14 +36,6 @@ module "repository_oidc" {
   role_configurations = [
     module.test_role.repository_oidc_configuration,
   ]
-}
-
-resource "github_actions_secret" "test_role_arn" {
-  repository  = local.github_repository_name
-  secret_name = "AWS_GHA_TEST_ROLE_ARN"
-  value       = module.test_role.role_arn
-
-  depends_on = [module.repository_oidc]
 }
 
 resource "github_actions_secret" "aws_region" {

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,68 @@
+locals {
+  github_oidc_provider_url = "https://token.actions.githubusercontent.com"
+  github_repository_name   = split("/", var.github_repository)[1]
+  test_role_name           = "eco-infra-infra-tests"
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  arn = var.github_oidc_provider_arn
+  url = var.github_oidc_provider_arn == null ? local.github_oidc_provider_url : null
+
+  lifecycle {
+    postcondition {
+      condition     = contains(self.client_id_list, "sts.amazonaws.com")
+      error_message = "The GitHub OIDC provider must include sts.amazonaws.com in its client ID list."
+    }
+  }
+}
+
+module "test_role" {
+  source = "../modules/internal/github-actions-aws-role"
+
+  role_name                = local.test_role_name
+  role_description         = "Role assumed by the eco-infra-infra tests workflow."
+  github_oidc_provider_arn = data.aws_iam_openid_connect_provider.github.arn
+  github_repository        = var.github_repository
+
+  trusted_workflows = [
+    {
+      workflow_filename = "tests.yaml"
+      context = {
+        type  = "branch"
+        value = "main"
+      }
+    },
+    {
+      workflow_filename = "tests.yaml"
+      context = {
+        type = "pull_request"
+      }
+    },
+  ]
+
+  tags = var.tags
+}
+
+module "repository_oidc" {
+  source = "../modules/internal/repo-oidc-customization"
+
+  role_configurations = [
+    module.test_role.repository_oidc_configuration,
+  ]
+}
+
+resource "github_actions_secret" "test_role_arn" {
+  repository  = local.github_repository_name
+  secret_name = "AWS_GHA_TEST_ROLE_ARN"
+  value       = module.test_role.role_arn
+
+  depends_on = [module.repository_oidc]
+}
+
+resource "github_actions_secret" "aws_region" {
+  repository  = local.github_repository_name
+  secret_name = "AWS_REGION"
+  value       = var.aws_region
+
+  depends_on = [module.repository_oidc]
+}

--- a/bootstrap/main.tftest.hcl
+++ b/bootstrap/main.tftest.hcl
@@ -7,7 +7,7 @@ mock_provider "github" {
 }
 
 override_data {
-  target = data.aws_iam_openid_connect_provider.github
+  target = module.test_role.data.aws_iam_openid_connect_provider.github_by_url
   values = {
     arn            = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
     client_id_list = ["sts.amazonaws.com"]
@@ -57,12 +57,40 @@ run "bootstrap_contract" {
   }
 
   assert {
-    condition     = github_actions_secret.test_role_arn.secret_name == "AWS_GHA_TEST_ROLE_ARN"
+    condition     = module.test_role.role_secret_name == "AWS_GHA_TEST_ROLE_ARN"
     error_message = "Bootstrap should publish the test role ARN under the expected secret name."
   }
 
   assert {
     condition     = github_actions_secret.aws_region.secret_name == "AWS_REGION"
     error_message = "Bootstrap should publish the AWS region under the expected secret name."
+  }
+}
+
+run "custom_role_names" {
+  command = plan
+
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  variables {
+    role_name        = "custom-tests-role"
+    role_secret_name = "CUSTOM_TEST_ROLE_ARN"
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = output.test_role_name == "custom-tests-role"
+    error_message = "Bootstrap should pass a custom role name to the role module."
+  }
+
+  assert {
+    condition     = module.test_role.role_secret_name == "CUSTOM_TEST_ROLE_ARN"
+    error_message = "Bootstrap should pass a custom role secret name to the role module."
   }
 }

--- a/bootstrap/main.tftest.hcl
+++ b/bootstrap/main.tftest.hcl
@@ -1,0 +1,68 @@
+mock_provider "aws" {
+  alias = "mock"
+}
+
+mock_provider "github" {
+  alias = "mock"
+}
+
+override_data {
+  target = data.aws_iam_openid_connect_provider.github
+  values = {
+    arn            = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    client_id_list = ["sts.amazonaws.com"]
+  }
+}
+
+override_resource {
+  target = module.test_role.aws_iam_role.github_actions
+  values = {
+    arn = "arn:aws:iam::123456789012:role/eco-infra-infra-tests"
+  }
+}
+
+run "bootstrap_contract" {
+  command = plan
+
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = output.github_oidc_provider_arn == "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    error_message = "Bootstrap should expose the discovered GitHub OIDC provider ARN."
+  }
+
+  assert {
+    condition     = output.test_role_name == "eco-infra-infra-tests"
+    error_message = "Bootstrap should create the expected test role."
+  }
+
+  assert {
+    condition = tolist(module.test_role.oidc_subjects) == tolist([
+      "repo:omsf-eco-infra/eco-infra-infra:pull_request:workflow_ref:omsf-eco-infra/eco-infra-infra/.github/workflows/tests.yaml@refs/pull/*/merge",
+      "repo:omsf-eco-infra/eco-infra-infra:ref:refs/heads/main:workflow_ref:omsf-eco-infra/eco-infra-infra/.github/workflows/tests.yaml@refs/heads/main",
+    ])
+    error_message = "The test role should trust only main and pull-request runs of tests.yaml."
+  }
+
+  assert {
+    condition     = module.repository_oidc.github_repository == var.github_repository
+    error_message = "Repository OIDC customization should consume the test role contract."
+  }
+
+  assert {
+    condition     = github_actions_secret.test_role_arn.secret_name == "AWS_GHA_TEST_ROLE_ARN"
+    error_message = "Bootstrap should publish the test role ARN under the expected secret name."
+  }
+
+  assert {
+    condition     = github_actions_secret.aws_region.secret_name == "AWS_REGION"
+    error_message = "Bootstrap should publish the AWS region under the expected secret name."
+  }
+}

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "github_oidc_provider_arn" {
+  description = "ARN of the account-wide GitHub Actions OIDC provider."
+  value       = data.aws_iam_openid_connect_provider.github.arn
+}
+
+output "test_role_name" {
+  description = "Name of the GitHub Actions test role."
+  value       = module.test_role.role_name
+}
+
+output "test_role_arn" {
+  description = "ARN of the GitHub Actions test role."
+  value       = module.test_role.role_arn
+}

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,6 +1,6 @@
 output "github_oidc_provider_arn" {
   description = "ARN of the account-wide GitHub Actions OIDC provider."
-  value       = data.aws_iam_openid_connect_provider.github.arn
+  value       = module.test_role.github_oidc_provider_arn
 }
 
 output "test_role_name" {

--- a/bootstrap/providers.tf
+++ b/bootstrap/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.10.0"
 
   backend "s3" {
     key          = "eco-infra-infra-tests/bootstrap/terraform.tfstate"

--- a/bootstrap/providers.tf
+++ b/bootstrap/providers.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  backend "s3" {
+    key          = "eco-infra-infra-tests/bootstrap/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "github" {
+  owner = split("/", var.github_repository)[0]
+}

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -34,6 +34,31 @@ variable "github_oidc_provider_arn" {
   }
 }
 
+variable "role_name" {
+  description = "Name of the IAM role assumed by the tests workflow."
+  type        = string
+  default     = "eco-infra-infra-tests"
+
+  validation {
+    condition     = length(trimspace(var.role_name)) > 0 && length(var.role_name) <= 64
+    error_message = "role_name must be non-empty and no longer than 64 characters."
+  }
+}
+
+variable "role_secret_name" {
+  description = "Name of the GitHub Actions repository secret that stores the test role ARN."
+  type        = string
+  default     = "AWS_GHA_TEST_ROLE_ARN"
+
+  validation {
+    condition = (
+      can(regex("^[A-Za-z_][A-Za-z0-9_]*$", var.role_secret_name)) &&
+      !startswith(upper(var.role_secret_name), "GITHUB_")
+    )
+    error_message = "role_secret_name may contain only letters, numbers, and underscores; it cannot start with a number or GITHUB_."
+  }
+}
+
 variable "tags" {
   description = "Tags to apply to the GitHub Actions test role."
   type        = map(string)

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -28,7 +28,7 @@ variable "github_oidc_provider_arn" {
   validation {
     condition = (
       var.github_oidc_provider_arn == null ||
-      can(regex(":iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
+      can(regex("^arn:[^:]+:iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
     )
     error_message = "github_oidc_provider_arn must identify token.actions.githubusercontent.com in an AWS account."
   }

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,0 +1,41 @@
+variable "github_repository" {
+  description = "GitHub repository that owns the tests workflow, in owner/repo form."
+  type        = string
+  default     = "omsf-eco-infra/eco-infra-infra"
+
+  validation {
+    condition     = can(regex("^[^/[:space:]]+/[^/[:space:]]+$", var.github_repository))
+    error_message = "github_repository must be in owner/repo form."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region used by the bootstrap stack and tests workflow."
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = length(trimspace(var.aws_region)) > 0
+    error_message = "aws_region cannot be empty."
+  }
+}
+
+variable "github_oidc_provider_arn" {
+  description = "Optional ARN of the account-wide GitHub Actions OIDC provider. When omitted, the provider is discovered by URL."
+  type        = string
+  default     = null
+
+  validation {
+    condition = (
+      var.github_oidc_provider_arn == null ||
+      can(regex(":iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
+    )
+    error_message = "github_oidc_provider_arn must identify token.actions.githubusercontent.com in an AWS account."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to the GitHub Actions test role."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/internal/github-actions-aws-role/README.md
+++ b/modules/internal/github-actions-aws-role/README.md
@@ -1,0 +1,150 @@
+# github-actions-aws-role
+
+Creates an AWS IAM role that only explicitly configured GitHub Actions caller
+workflows can assume. The module also attaches caller-supplied inline and
+managed IAM policies.
+
+This is an internal building block. It expects the repository to use the OIDC
+subject template managed by
+[`../repo-oidc-customization`](../repo-oidc-customization), which emits subjects
+containing `repo`, `context`, and `workflow_ref`.
+
+## Usage
+
+```hcl
+module "deploy_role" {
+  source = "github.com/omsf-eco-infra/eco-infra-infra//modules/internal/github-actions-aws-role"
+
+  role_name                = "example-deployer"
+  github_oidc_provider_arn = module.github_oidc.github_oidc_provider_arn
+  github_repository        = "example-org/example-repo"
+
+  trusted_workflows = [
+    {
+      workflow_filename = "deploy.yml"
+      workflow_ref      = "refs/heads/main"
+      context = {
+        type  = "branch"
+        value = "main"
+      }
+    },
+    {
+      workflow_filename = "deploy.yml"
+      workflow_ref      = "refs/pull/*"
+      context = {
+        type = "pull_request"
+      }
+    },
+  ]
+
+  inline_policies = {
+    deploy = data.aws_iam_policy_document.deploy.json
+  }
+
+  managed_policy_arns = {
+    shared-read = aws_iam_policy.shared_read.arn
+  }
+
+  tags = {
+    managed_by = "tofu"
+  }
+}
+
+module "repository_oidc" {
+  source = "github.com/omsf-eco-infra/eco-infra-infra//modules/internal/repo-oidc-customization"
+
+  role_configurations = [
+    module.deploy_role.repository_oidc_configuration,
+  ]
+}
+```
+
+The GitHub provider passed to `repository_oidc` must be configured for
+`example-org`. Keep repository secrets and variables in the calling module.
+
+## Workflow trust entries
+
+Each entry represents one exact workflow/ref/context combination. Supported
+contexts are:
+
+| Type | Value | Subject context | Default workflow ref |
+| --- | --- | --- | --- |
+| `branch` | Required; patterns allowed | `ref:refs/heads/<value>` | `refs/heads/<value>` |
+| `tag` | Required; patterns allowed | `ref:refs/tags/<value>` | `refs/tags/<value>` |
+| `pull_request` | Omit | `pull_request` | `refs/pull/*/merge` |
+| `environment` | Required; patterns allowed | `environment:<value>` | None; explicit ref required |
+| `any` | Omit | `*` | `refs/*` |
+
+`workflow_ref` is optional except for environment contexts. An explicitly
+provided value always overrides the context-derived default. The pull-request
+default covers ordinary open `pull_request` runs; merged/closed PR jobs and
+`pull_request_target` workflows should provide the ref pattern they actually
+use.
+
+Colons in context values are encoded as `%3A`. Every resulting subject also
+contains the repository and caller workflow identity:
+
+```text
+repo:owner/repo:<context>:workflow_ref:owner/repo/.github/workflows/file.yml@refs/...
+```
+
+`any` retains workflow-level restriction while accepting every GitHub subject
+context. Because subjects use IAM `StringLike`, wildcards in context values and
+workflow refs are meaningful and should be reviewed carefully.
+
+## Inputs
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `role_name` | `string` | required | IAM role name |
+| `github_oidc_provider_arn` | `string` | required | Account GitHub OIDC provider ARN |
+| `github_repository` | `string` | required | Repository in `owner/repo` form |
+| `trusted_workflows` | `list(object)` | required | Exact allowed workflow combinations; workflow refs may use context defaults |
+| `role_description` | `string` | workflow-role description | IAM role description |
+| `max_session_duration` | `number` | `3600` | Session limit from 3600 through 43200 seconds |
+| `force_detach_policies` | `bool` | `false` | Detach out-of-band policies during role deletion |
+| `github_audience` | `string` | `sts.amazonaws.com` | Required OIDC audience |
+| `inline_policies` | `map(string)` | `{}` | Stable policy names mapped to JSON documents |
+| `managed_policy_arns` | `map(string)` | `{}` | Stable attachment keys mapped to policy ARNs |
+| `tags` | `map(string)` | `{}` | IAM role tags |
+
+## Outputs
+
+- `role_name` and `role_arn`
+- `assume_role_policy_json`
+- `oidc_subjects`
+- `repository_oidc_configuration`: non-sensitive readiness contract for the
+  repository customization module
+
+## Compatibility and migration
+
+- The module targets caller workflows with `workflow_ref`. It does not enforce
+  reusable workflows with `job_workflow_ref`.
+- It intentionally has no raw or default-subject mode.
+- V1 constructs GitHub's name-based subjects. GitHub repositories using the
+  immutable owner/repository-ID subject format are not supported until the
+  GitHub Terraform provider can manage `use_immutable_subject` end to end.
+  GitHub begins using immutable subjects by default for newly created
+  repositories on July 15, 2026, so check the repository setting before use.
+- Changing a repository's OIDC template changes tokens for every role used by
+  that repository. Migrate all roles before applying the repository module.
+  When replacing live roles, use parallel roles and switch workflow secrets
+  only after the new template is active.
+- For roles in another Terraform state or AWS account, apply every role state
+  before the state containing `repo-oidc-customization`.
+
+### Existing implementation mappings
+
+- **ami-builder:** use `any` context with `refs/*` where all events are needed,
+  pass Packer/cleanup/test permissions as inline policies, and aggregate every
+  role contract into one repository customization. This replaces its custom
+  `job_workflow_ref` subject with caller `workflow_ref`.
+- **cloud-cron:** continue generating its service-specific managed permission
+  sets outside this module and pass their ARNs through `managed_policy_arns`.
+  Express each existing branch/environment subject and workflow pairing as an
+  exact trust entry instead of using an independent `job_workflow_ref` IAM
+  condition.
+- **website-backend:** continue using `modules/github-oidc` for the account
+  provider, pass the sandbox document through `inline_policies`, and use
+  separate main-branch and pull-request trust entries for `terraform.yaml`.
+  GitHub secrets remain in the bootstrap wrapper.

--- a/modules/internal/github-actions-aws-role/README.md
+++ b/modules/internal/github-actions-aws-role/README.md
@@ -2,7 +2,8 @@
 
 Creates an AWS IAM role that only explicitly configured GitHub Actions caller
 workflows can assume. The module also attaches caller-supplied inline and
-managed IAM policies.
+managed IAM policies, discovers the account-wide GitHub OIDC provider when its
+ARN is omitted, and publishes the role ARN as a repository Actions secret.
 
 This is an internal building block. It expects the repository to use the OIDC
 subject template managed by
@@ -15,9 +16,9 @@ containing `repo`, `context`, and `workflow_ref`.
 module "deploy_role" {
   source = "github.com/omsf-eco-infra/eco-infra-infra//modules/internal/github-actions-aws-role"
 
-  role_name                = "example-deployer"
-  github_oidc_provider_arn = module.github_oidc.github_oidc_provider_arn
-  github_repository        = "example-org/example-repo"
+  role_name         = "example-deployer"
+  role_secret_name  = "AWS_DEPLOY_ROLE_ARN"
+  github_repository = "example-org/example-repo"
 
   trusted_workflows = [
     {
@@ -59,8 +60,15 @@ module "repository_oidc" {
 }
 ```
 
-The GitHub provider passed to `repository_oidc` must be configured for
-`example-org`. Keep repository secrets and variables in the calling module.
+The AWS provider must select the account containing the role and GitHub OIDC
+provider. The GitHub provider passed to this module and `repository_oidc` must
+be configured for `example-org`. Set `github_oidc_provider_arn` to select a
+specific provider; otherwise the module looks up
+`https://token.actions.githubusercontent.com` in the selected AWS account.
+
+The role secret is created after the IAM role, but it can be created in
+parallel with the separate repository OIDC customization. A workflow started
+during that apply can fail until customization is complete.
 
 ## Workflow trust entries
 
@@ -97,7 +105,8 @@ workflow refs are meaningful and should be reviewed carefully.
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `role_name` | `string` | required | IAM role name |
-| `github_oidc_provider_arn` | `string` | required | Account GitHub OIDC provider ARN |
+| `role_secret_name` | `string` | required | Repository Actions secret that receives the role ARN |
+| `github_oidc_provider_arn` | `string` | `null` | Optional account GitHub OIDC provider ARN; discovered by URL when omitted |
 | `github_repository` | `string` | required | Repository in `owner/repo` form |
 | `trusted_workflows` | `list(object)` | required | Exact allowed workflow combinations; workflow refs may use context defaults |
 | `role_description` | `string` | workflow-role description | IAM role description |
@@ -111,6 +120,7 @@ workflow refs are meaningful and should be reviewed carefully.
 ## Outputs
 
 - `role_name` and `role_arn`
+- `github_oidc_provider_arn` and `role_secret_name`
 - `assume_role_policy_json`
 - `oidc_subjects`
 - `repository_oidc_configuration`: non-sensitive readiness contract for the
@@ -147,4 +157,4 @@ workflow refs are meaningful and should be reviewed carefully.
 - **website-backend:** continue using `modules/github-oidc` for the account
   provider, pass the sandbox document through `inline_policies`, and use
   separate main-branch and pull-request trust entries for `terraform.yaml`.
-  GitHub secrets remain in the bootstrap wrapper.
+  Pass the existing role-secret name to this module.

--- a/modules/internal/github-actions-aws-role/main.tf
+++ b/modules/internal/github-actions-aws-role/main.tf
@@ -1,5 +1,8 @@
 locals {
-  subject_claim_keys = ["repo", "context", "workflow_ref"]
+  github_oidc_provider_url = "https://token.actions.githubusercontent.com"
+  github_repository_name   = split("/", var.github_repository)[1]
+  github_oidc_provider_arn = var.github_oidc_provider_arn == null ? data.aws_iam_openid_connect_provider.github_by_url[0].arn : data.aws_iam_openid_connect_provider.github_by_arn[0].arn
+  subject_claim_keys       = ["repo", "context", "workflow_ref"]
 
   trusted_workflow_contexts = [
     for workflow in var.trusted_workflows :
@@ -28,7 +31,7 @@ locals {
       Sid    = "GitHubActionsAssumeRole"
       Effect = "Allow"
       Principal = {
-        Federated = var.github_oidc_provider_arn
+        Federated = local.github_oidc_provider_arn
       }
       Action = "sts:AssumeRoleWithWebIdentity"
       Condition = {
@@ -40,6 +43,32 @@ locals {
         }
       }
     }]
+  }
+}
+
+data "aws_iam_openid_connect_provider" "github_by_url" {
+  count = var.github_oidc_provider_arn == null ? 1 : 0
+
+  url = local.github_oidc_provider_url
+
+  lifecycle {
+    postcondition {
+      condition     = contains(self.client_id_list, var.github_audience)
+      error_message = "The GitHub OIDC provider must include github_audience in its client ID list."
+    }
+  }
+}
+
+data "aws_iam_openid_connect_provider" "github_by_arn" {
+  count = var.github_oidc_provider_arn == null ? 0 : 1
+
+  arn = var.github_oidc_provider_arn
+
+  lifecycle {
+    postcondition {
+      condition     = contains(self.client_id_list, var.github_audience)
+      error_message = "The GitHub OIDC provider must include github_audience in its client ID list."
+    }
   }
 }
 
@@ -65,4 +94,10 @@ resource "aws_iam_role_policy_attachment" "managed" {
 
   role       = aws_iam_role.github_actions.name
   policy_arn = each.value
+}
+
+resource "github_actions_secret" "role_arn" {
+  repository  = local.github_repository_name
+  secret_name = var.role_secret_name
+  value       = aws_iam_role.github_actions.arn
 }

--- a/modules/internal/github-actions-aws-role/main.tf
+++ b/modules/internal/github-actions-aws-role/main.tf
@@ -1,0 +1,68 @@
+locals {
+  subject_claim_keys = ["repo", "context", "workflow_ref"]
+
+  trusted_workflow_contexts = [
+    for workflow in var.trusted_workflows :
+    workflow.context.type == "branch" ? "ref:refs/heads/${replace(workflow.context.value, ":", "%3A")}" :
+    workflow.context.type == "tag" ? "ref:refs/tags/${replace(workflow.context.value, ":", "%3A")}" :
+    workflow.context.type == "environment" ? "environment:${replace(workflow.context.value, ":", "%3A")}" :
+    workflow.context.type == "pull_request" ? "pull_request" : "*"
+  ]
+
+  trusted_workflow_refs = [
+    for workflow in var.trusted_workflows :
+    workflow.workflow_ref != null ? workflow.workflow_ref :
+    workflow.context.type == "branch" ? "refs/heads/${workflow.context.value}" :
+    workflow.context.type == "tag" ? "refs/tags/${workflow.context.value}" :
+    workflow.context.type == "pull_request" ? "refs/pull/*/merge" : "refs/*"
+  ]
+
+  oidc_subjects = sort(distinct([
+    for index, workflow in var.trusted_workflows :
+    "repo:${var.github_repository}:${local.trusted_workflow_contexts[index]}:workflow_ref:${var.github_repository}/.github/workflows/${workflow.workflow_filename}@${local.trusted_workflow_refs[index]}"
+  ]))
+
+  assume_role_policy = {
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "GitHubActionsAssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Federated = var.github_oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = var.github_audience
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = local.oidc_subjects
+        }
+      }
+    }]
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name                  = var.role_name
+  description           = var.role_description
+  assume_role_policy    = jsonencode(local.assume_role_policy)
+  max_session_duration  = var.max_session_duration
+  force_detach_policies = var.force_detach_policies
+  tags                  = var.tags
+}
+
+resource "aws_iam_role_policy" "inline" {
+  for_each = var.inline_policies
+
+  name   = each.key
+  role   = aws_iam_role.github_actions.id
+  policy = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "managed" {
+  for_each = var.managed_policy_arns
+
+  role       = aws_iam_role.github_actions.name
+  policy_arn = each.value
+}

--- a/modules/internal/github-actions-aws-role/main.tftest.hcl
+++ b/modules/internal/github-actions-aws-role/main.tftest.hcl
@@ -2,13 +2,32 @@ mock_provider "aws" {
   alias = "mock"
 }
 
+mock_provider "github" {
+  alias = "mock"
+}
+
+override_data {
+  target = data.aws_iam_openid_connect_provider.github_by_url
+  values = {
+    arn            = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    client_id_list = ["sts.amazonaws.com"]
+  }
+}
+
+override_resource {
+  target = aws_iam_role.github_actions
+  values = {
+    arn = "arn:aws:iam::123456789012:role/example-github-actions"
+  }
+}
+
 variables {
-  role_name                = "example-github-actions"
-  role_description         = "Example workflow role"
-  max_session_duration     = 7200
-  force_detach_policies    = true
-  github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
-  github_repository        = "example-org/example-repo"
+  role_name             = "example-github-actions"
+  role_description      = "Example workflow role"
+  max_session_duration  = 7200
+  force_detach_policies = true
+  github_repository     = "example-org/example-repo"
+  role_secret_name      = "AWS_EXAMPLE_ROLE_ARN"
 
   trusted_workflows = [
     {
@@ -70,7 +89,8 @@ variables {
 run "role_configuration" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   plan_options {
@@ -90,6 +110,26 @@ run "role_configuration" {
   assert {
     condition     = aws_iam_role.github_actions.force_detach_policies
     error_message = "The role should preserve force_detach_policies."
+  }
+
+  assert {
+    condition     = output.github_oidc_provider_arn == "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    error_message = "The module should discover and expose the GitHub OIDC provider ARN."
+  }
+
+  assert {
+    condition     = github_actions_secret.role_arn.repository == "example-repo"
+    error_message = "The role secret should be created in the configured repository."
+  }
+
+  assert {
+    condition     = github_actions_secret.role_arn.secret_name == "AWS_EXAMPLE_ROLE_ARN"
+    error_message = "The role secret should use the requested name."
+  }
+
+  assert {
+    condition     = github_actions_secret.role_arn.value == "arn:aws:iam::123456789012:role/example-github-actions"
+    error_message = "The role secret should contain the role ARN."
   }
 
   assert {
@@ -129,10 +169,35 @@ run "role_configuration" {
   }
 }
 
+run "explicit_oidc_provider_arn" {
+  command = plan
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  variables {
+    github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+  }
+
+  override_data {
+    target = data.aws_iam_openid_connect_provider.github_by_arn
+    values = {
+      client_id_list = ["sts.amazonaws.com"]
+    }
+  }
+
+  assert {
+    condition     = output.github_oidc_provider_arn == var.github_oidc_provider_arn
+    error_message = "An explicit GitHub OIDC provider ARN should be preserved."
+  }
+}
+
 run "reject_invalid_repository" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -145,7 +210,8 @@ run "reject_invalid_repository" {
 run "reject_empty_workflows" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -158,7 +224,8 @@ run "reject_empty_workflows" {
 run "reject_invalid_context" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -177,7 +244,8 @@ run "reject_invalid_context" {
 run "reject_invalid_workflow_filename" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -197,7 +265,8 @@ run "reject_invalid_workflow_filename" {
 run "reject_invalid_workflow_ref" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -217,7 +286,8 @@ run "reject_invalid_workflow_ref" {
 run "reject_environment_without_workflow_ref" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -236,7 +306,8 @@ run "reject_environment_without_workflow_ref" {
 run "reject_malformed_inline_policy" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -251,7 +322,8 @@ run "reject_malformed_inline_policy" {
 run "reject_invalid_session_duration" {
   command = plan
   providers = {
-    aws = aws.mock
+    aws    = aws.mock
+    github = github.mock
   }
 
   variables {
@@ -259,4 +331,18 @@ run "reject_invalid_session_duration" {
   }
 
   expect_failures = [var.max_session_duration]
+}
+
+run "reject_invalid_role_secret_name" {
+  command = plan
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  variables {
+    role_secret_name = "GITHUB_ROLE_ARN"
+  }
+
+  expect_failures = [var.role_secret_name]
 }

--- a/modules/internal/github-actions-aws-role/main.tftest.hcl
+++ b/modules/internal/github-actions-aws-role/main.tftest.hcl
@@ -1,0 +1,262 @@
+mock_provider "aws" {
+  alias = "mock"
+}
+
+variables {
+  role_name                = "example-github-actions"
+  role_description         = "Example workflow role"
+  max_session_duration     = 7200
+  force_detach_policies    = true
+  github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+  github_repository        = "example-org/example-repo"
+
+  trusted_workflows = [
+    {
+      workflow_filename = "deploy.yaml"
+      context = {
+        type  = "branch"
+        value = "main"
+      }
+    },
+    {
+      workflow_filename = "deploy.yaml"
+      context = {
+        type = "pull_request"
+      }
+    },
+    {
+      workflow_filename = "release.yml"
+      context = {
+        type  = "tag"
+        value = "v*"
+      }
+    },
+    {
+      workflow_filename = "deploy.yaml"
+      workflow_ref      = "refs/heads/main"
+      context = {
+        type  = "environment"
+        value = "production:blue"
+      }
+    },
+    {
+      workflow_filename = "maintenance.yml"
+      context = {
+        type = "any"
+      }
+    },
+  ]
+
+  inline_policies = {
+    deploy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = ["s3:ListAllMyBuckets"]
+        Resource = "*"
+      }]
+    })
+  }
+
+  managed_policy_arns = {
+    readonly = "arn:aws:iam::123456789012:policy/example-readonly"
+  }
+
+  tags = {
+    managed_by = "tofu"
+  }
+}
+
+run "role_configuration" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = aws_iam_role.github_actions.name == "example-github-actions"
+    error_message = "The role should use the requested name."
+  }
+
+  assert {
+    condition     = aws_iam_role.github_actions.max_session_duration == 7200
+    error_message = "The role should use the requested maximum session duration."
+  }
+
+  assert {
+    condition     = aws_iam_role.github_actions.force_detach_policies
+    error_message = "The role should preserve force_detach_policies."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy.inline["deploy"].name == "deploy"
+    error_message = "Inline policy map keys should provide stable policy names."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.managed["readonly"].policy_arn == "arn:aws:iam::123456789012:policy/example-readonly"
+    error_message = "Managed policy map entries should create stable attachments."
+  }
+
+  assert {
+    condition = output.oidc_subjects == sort([
+      "repo:example-org/example-repo:ref:refs/heads/main:workflow_ref:example-org/example-repo/.github/workflows/deploy.yaml@refs/heads/main",
+      "repo:example-org/example-repo:pull_request:workflow_ref:example-org/example-repo/.github/workflows/deploy.yaml@refs/pull/*/merge",
+      "repo:example-org/example-repo:ref:refs/tags/v*:workflow_ref:example-org/example-repo/.github/workflows/release.yml@refs/tags/v*",
+      "repo:example-org/example-repo:environment:production%3Ablue:workflow_ref:example-org/example-repo/.github/workflows/deploy.yaml@refs/heads/main",
+      "repo:example-org/example-repo:*:workflow_ref:example-org/example-repo/.github/workflows/maintenance.yml@refs/*",
+    ])
+    error_message = "OIDC subjects should encode every exact workflow/context combination."
+  }
+
+  assert {
+    condition     = output.repository_oidc_configuration.github_repository == "example-org/example-repo"
+    error_message = "The repository customization contract should carry the repository."
+  }
+
+  assert {
+    condition     = output.repository_oidc_configuration.include_claim_keys == ["repo", "context", "workflow_ref"]
+    error_message = "The repository customization contract should use the standardized claim order."
+  }
+
+  assert {
+    condition     = !strcontains(output.assume_role_policy_json, "job_workflow_ref")
+    error_message = "The trust policy must not use AWS's unsupported independent job_workflow_ref condition."
+  }
+}
+
+run "reject_invalid_repository" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    github_repository = "missing-owner"
+  }
+
+  expect_failures = [var.github_repository]
+}
+
+run "reject_empty_workflows" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    trusted_workflows = []
+  }
+
+  expect_failures = [var.trusted_workflows]
+}
+
+run "reject_invalid_context" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    trusted_workflows = [{
+      workflow_filename = "deploy.yaml"
+      workflow_ref      = "refs/heads/main"
+      context = {
+        type = "environment"
+      }
+    }]
+  }
+
+  expect_failures = [var.trusted_workflows]
+}
+
+run "reject_invalid_workflow_filename" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    trusted_workflows = [{
+      workflow_filename = "nested/deploy.yaml"
+      workflow_ref      = "refs/heads/main"
+      context = {
+        type  = "branch"
+        value = "main"
+      }
+    }]
+  }
+
+  expect_failures = [var.trusted_workflows]
+}
+
+run "reject_invalid_workflow_ref" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    trusted_workflows = [{
+      workflow_filename = "deploy.yaml"
+      workflow_ref      = "main"
+      context = {
+        type  = "branch"
+        value = "main"
+      }
+    }]
+  }
+
+  expect_failures = [var.trusted_workflows]
+}
+
+run "reject_environment_without_workflow_ref" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    trusted_workflows = [{
+      workflow_filename = "deploy.yaml"
+      context = {
+        type  = "environment"
+        value = "production"
+      }
+    }]
+  }
+
+  expect_failures = [var.trusted_workflows]
+}
+
+run "reject_malformed_inline_policy" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    inline_policies = {
+      broken = "not-json"
+    }
+  }
+
+  expect_failures = [var.inline_policies]
+}
+
+run "reject_invalid_session_duration" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    max_session_duration = 3599
+  }
+
+  expect_failures = [var.max_session_duration]
+}

--- a/modules/internal/github-actions-aws-role/outputs.tf
+++ b/modules/internal/github-actions-aws-role/outputs.tf
@@ -1,0 +1,28 @@
+output "role_name" {
+  description = "Name of the GitHub Actions IAM role."
+  value       = aws_iam_role.github_actions.name
+}
+
+output "role_arn" {
+  description = "ARN of the GitHub Actions IAM role."
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "assume_role_policy_json" {
+  description = "Rendered IAM trust policy JSON."
+  value       = jsonencode(local.assume_role_policy)
+}
+
+output "oidc_subjects" {
+  description = "Sorted customized OIDC subjects allowed to assume the role."
+  value       = local.oidc_subjects
+}
+
+output "repository_oidc_configuration" {
+  description = "Repository OIDC contract consumed by the repo-oidc-customization module."
+  value = {
+    github_repository  = var.github_repository
+    include_claim_keys = local.subject_claim_keys
+    ready_role_arn     = aws_iam_role.github_actions.arn
+  }
+}

--- a/modules/internal/github-actions-aws-role/outputs.tf
+++ b/modules/internal/github-actions-aws-role/outputs.tf
@@ -8,6 +8,16 @@ output "role_arn" {
   value       = aws_iam_role.github_actions.arn
 }
 
+output "github_oidc_provider_arn" {
+  description = "ARN of the resolved account-wide GitHub Actions OIDC provider."
+  value       = local.github_oidc_provider_arn
+}
+
+output "role_secret_name" {
+  description = "Name of the GitHub Actions repository secret containing the role ARN."
+  value       = github_actions_secret.role_arn.secret_name
+}
+
 output "assume_role_policy_json" {
   description = "Rendered IAM trust policy JSON."
   value       = jsonencode(local.assume_role_policy)

--- a/modules/internal/github-actions-aws-role/providers.tf
+++ b/modules/internal/github-actions-aws-role/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/internal/github-actions-aws-role/providers.tf
+++ b/modules/internal/github-actions-aws-role/providers.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.0"
     }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
   }
 }

--- a/modules/internal/github-actions-aws-role/variables.tf
+++ b/modules/internal/github-actions-aws-role/variables.tf
@@ -1,0 +1,156 @@
+variable "role_name" {
+  description = "Name of the IAM role that GitHub Actions workflows assume."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.role_name)) > 0 && length(var.role_name) <= 64
+    error_message = "role_name must be non-empty and no longer than 64 characters."
+  }
+}
+
+variable "role_description" {
+  description = "Description for the GitHub Actions IAM role."
+  type        = string
+  default     = "Role assumed by explicitly trusted GitHub Actions workflows."
+}
+
+variable "max_session_duration" {
+  description = "Maximum duration, in seconds, for sessions assumed through this role."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds."
+  }
+}
+
+variable "force_detach_policies" {
+  description = "Detach policies attached outside this module before deleting the role."
+  type        = bool
+  default     = false
+}
+
+variable "github_oidc_provider_arn" {
+  description = "ARN of the account's GitHub Actions OIDC identity provider."
+  type        = string
+
+  validation {
+    condition     = can(regex(":iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
+    error_message = "github_oidc_provider_arn must identify token.actions.githubusercontent.com in an AWS account."
+  }
+}
+
+variable "github_audience" {
+  description = "Audience expected in GitHub's OIDC token."
+  type        = string
+  default     = "sts.amazonaws.com"
+
+  validation {
+    condition     = length(trimspace(var.github_audience)) > 0
+    error_message = "github_audience cannot be empty."
+  }
+}
+
+variable "github_repository" {
+  description = "GitHub repository in owner/repo form."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^/[:space:]]+/[^/[:space:]]+$", var.github_repository))
+    error_message = "github_repository must be in owner/repo form."
+  }
+}
+
+variable "trusted_workflows" {
+  description = "Exact workflow and subject-context combinations allowed to assume the role, with optional workflow-ref overrides."
+  type = list(object({
+    workflow_filename = string
+    workflow_ref      = optional(string)
+    context = object({
+      type  = string
+      value = optional(string)
+    })
+  }))
+
+  validation {
+    condition     = length(var.trusted_workflows) > 0
+    error_message = "trusted_workflows must contain at least one workflow entry."
+  }
+
+  validation {
+    condition = alltrue([
+      for workflow in var.trusted_workflows :
+      can(regex("^[^/]+\\.ya?ml$", workflow.workflow_filename))
+    ])
+    error_message = "Each workflow_filename must be a .yml or .yaml filename directly under .github/workflows."
+  }
+
+  validation {
+    condition = alltrue([
+      for workflow in var.trusted_workflows :
+      workflow.workflow_ref == null || can(regex("^refs/", workflow.workflow_ref))
+    ])
+    error_message = "Each explicit workflow_ref must start with refs/."
+  }
+
+  validation {
+    condition = alltrue([
+      for workflow in var.trusted_workflows :
+      contains(["branch", "tag", "pull_request", "environment", "any"], workflow.context.type)
+    ])
+    error_message = "Each context type must be branch, tag, pull_request, environment, or any."
+  }
+
+  validation {
+    condition = alltrue([
+      for workflow in var.trusted_workflows :
+      contains(["branch", "tag", "environment"], workflow.context.type)
+      ? try(length(trimspace(workflow.context.value)) > 0, false)
+      : workflow.context.value == null
+    ])
+    error_message = "Branch, tag, and environment contexts require a non-empty value; pull_request and any contexts must omit value."
+  }
+
+  validation {
+    condition = alltrue([
+      for workflow in var.trusted_workflows :
+      workflow.context.type != "environment" || workflow.workflow_ref != null
+    ])
+    error_message = "Environment contexts require an explicit workflow_ref because the environment does not identify the workflow's source ref."
+  }
+}
+
+variable "inline_policies" {
+  description = "Map of stable policy identifiers to inline IAM policy JSON documents."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for name, policy in var.inline_policies :
+      can(regex("^[0-9A-Za-z_+=,.@-]{1,128}$", name)) && can(keys(jsondecode(policy)))
+    ])
+    error_message = "inline_policies keys must be valid IAM inline policy names and values must be JSON objects."
+  }
+}
+
+variable "managed_policy_arns" {
+  description = "Map of stable attachment identifiers to managed IAM policy ARNs."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for name, arn in var.managed_policy_arns :
+      length(trimspace(name)) > 0 && can(regex("^arn:[^:]+:iam::([0-9]{12}|aws):policy/.+", arn))
+    ])
+    error_message = "managed_policy_arns keys must be non-empty and values must be IAM managed policy ARNs."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to the IAM role."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/internal/github-actions-aws-role/variables.tf
+++ b/modules/internal/github-actions-aws-role/variables.tf
@@ -39,7 +39,7 @@ variable "github_oidc_provider_arn" {
   validation {
     condition = (
       var.github_oidc_provider_arn == null ||
-      can(regex(":iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
+      can(regex("^arn:[^:]+:iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
     )
     error_message = "github_oidc_provider_arn must identify token.actions.githubusercontent.com in an AWS account."
   }

--- a/modules/internal/github-actions-aws-role/variables.tf
+++ b/modules/internal/github-actions-aws-role/variables.tf
@@ -32,11 +32,15 @@ variable "force_detach_policies" {
 }
 
 variable "github_oidc_provider_arn" {
-  description = "ARN of the account's GitHub Actions OIDC identity provider."
+  description = "Optional ARN of the account's GitHub Actions OIDC identity provider. When omitted, the provider is discovered by URL."
   type        = string
+  default     = null
 
   validation {
-    condition     = can(regex(":iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
+    condition = (
+      var.github_oidc_provider_arn == null ||
+      can(regex(":iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$", var.github_oidc_provider_arn))
+    )
     error_message = "github_oidc_provider_arn must identify token.actions.githubusercontent.com in an AWS account."
   }
 }
@@ -59,6 +63,19 @@ variable "github_repository" {
   validation {
     condition     = can(regex("^[^/[:space:]]+/[^/[:space:]]+$", var.github_repository))
     error_message = "github_repository must be in owner/repo form."
+  }
+}
+
+variable "role_secret_name" {
+  description = "Name of the GitHub Actions repository secret that stores the role ARN."
+  type        = string
+
+  validation {
+    condition = (
+      can(regex("^[A-Za-z_][A-Za-z0-9_]*$", var.role_secret_name)) &&
+      !startswith(upper(var.role_secret_name), "GITHUB_")
+    )
+    error_message = "role_secret_name may contain only letters, numbers, and underscores; it cannot start with a number or GITHUB_."
   }
 }
 

--- a/modules/internal/repo-oidc-customization/README.md
+++ b/modules/internal/repo-oidc-customization/README.md
@@ -1,0 +1,79 @@
+# repo-oidc-customization
+
+Configures one GitHub repository to emit OIDC subjects containing `repo`,
+`context`, and caller `workflow_ref`. It consumes readiness contracts from all
+of the repository's `github-actions-aws-role` modules.
+
+The dependency direction is deliberate: AWS trust policies are created or
+updated before GitHub changes the token format.
+
+## Usage
+
+```hcl
+provider "github" {
+  owner = "example-org"
+}
+
+module "deploy_role" {
+  source = "../github-actions-aws-role"
+  # Role inputs omitted.
+}
+
+module "test_role" {
+  source = "../github-actions-aws-role"
+  # Role inputs omitted.
+}
+
+module "repository_oidc" {
+  source = "github.com/omsf-eco-infra/eco-infra-infra//modules/internal/repo-oidc-customization"
+
+  role_configurations = [
+    module.deploy_role.repository_oidc_configuration,
+    module.test_role.repository_oidc_configuration,
+  ]
+}
+```
+
+All contracts must name the same repository and provide the same ordered claim
+keys. The GitHub provider must be configured for that repository's owner. The
+module passes the agreed claim keys through to GitHub rather than defining a
+second copy of the role module's subject format.
+
+## Ordering
+
+Within one Terraform graph, the role ARNs form an explicit dependency barrier,
+so the repository customization waits for every listed role. When roles and
+the repository setting use different states, apply all role states first.
+
+Do not omit a role that still receives OIDC tokens from the repository. The
+template is repository-wide, and changing it can prevent omitted roles from
+being assumed.
+
+On destruction, Terraform removes the repository customization before the
+roles it depends on. This safely stops customized tokens from matching before
+the corresponding roles disappear.
+
+## Inputs and outputs
+
+`role_configurations` is a non-empty list of contracts output by
+`github-actions-aws-role`. Each contains:
+
+- `github_repository`
+- `include_claim_keys`
+- `ready_role_arn`
+
+The module outputs `github_repository`, `include_claim_keys`, and
+`customization_id`.
+
+## Immutable subjects
+
+V1 supports existing name-based GitHub OIDC subjects only. GitHub's immutable
+subject format adds numeric owner and repository IDs, while the GitHub
+Terraform provider does not yet manage the corresponding
+`use_immutable_subject` setting end to end. Do not use this module for a
+repository emitting immutable subjects until that support is added. GitHub
+begins enabling immutable subjects by default for repositories created on or
+after July 15, 2026.
+
+See GitHub's [OIDC reference](https://docs.github.com/en/actions/reference/security/oidc)
+for subject customization and immutable-subject behavior.

--- a/modules/internal/repo-oidc-customization/contract.tftest.hcl
+++ b/modules/internal/repo-oidc-customization/contract.tftest.hcl
@@ -1,0 +1,41 @@
+mock_provider "aws" {
+  alias = "mock"
+}
+
+mock_provider "github" {
+  alias = "mock"
+}
+
+override_resource {
+  target = module.role.aws_iam_role.github_actions
+  values = {
+    arn = "arn:aws:iam::123456789012:role/contract-test"
+  }
+}
+
+run "role_to_repository_contract" {
+  command = plan
+
+  module {
+    source = "./tests/integration"
+  }
+
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = output.role_repository == output.customization_repository
+    error_message = "The role output should directly configure the same repository."
+  }
+
+  assert {
+    condition     = tolist(output.include_claim_keys) == tolist(["repo", "context", "workflow_ref"])
+    error_message = "The role and customization modules should agree on the claim contract."
+  }
+}

--- a/modules/internal/repo-oidc-customization/contract.tftest.hcl
+++ b/modules/internal/repo-oidc-customization/contract.tftest.hcl
@@ -13,6 +13,13 @@ override_resource {
   }
 }
 
+override_data {
+  target = module.role.data.aws_iam_openid_connect_provider.github_by_arn
+  values = {
+    client_id_list = ["sts.amazonaws.com"]
+  }
+}
+
 run "role_to_repository_contract" {
   command = plan
 

--- a/modules/internal/repo-oidc-customization/main.tf
+++ b/modules/internal/repo-oidc-customization/main.tf
@@ -1,0 +1,21 @@
+locals {
+  github_repository  = var.role_configurations[0].github_repository
+  repository_name    = split("/", local.github_repository)[1]
+  include_claim_keys = var.role_configurations[0].include_claim_keys
+  ready_role_arns    = sort(distinct([for configuration in var.role_configurations : configuration.ready_role_arn]))
+}
+
+# This barrier makes each role ARN an explicit dependency of the repository-wide
+# token-format change. GitHub therefore changes subjects only after every trust
+# policy represented by role_configurations has been created or updated.
+resource "terraform_data" "role_trust_policies_ready" {
+  input = local.ready_role_arns
+}
+
+resource "github_actions_repository_oidc_subject_claim_customization_template" "workflow" {
+  repository         = local.repository_name
+  use_default        = false
+  include_claim_keys = local.include_claim_keys
+
+  depends_on = [terraform_data.role_trust_policies_ready]
+}

--- a/modules/internal/repo-oidc-customization/main.tftest.hcl
+++ b/modules/internal/repo-oidc-customization/main.tftest.hcl
@@ -1,0 +1,138 @@
+mock_provider "github" {
+  alias = "mock"
+}
+
+variables {
+  role_configurations = [
+    {
+      github_repository  = "example-org/example-repo"
+      include_claim_keys = ["repo", "context", "workflow_ref"]
+      ready_role_arn     = "arn:aws:iam::123456789012:role/example-deploy"
+    },
+    {
+      github_repository  = "example-org/example-repo"
+      include_claim_keys = ["repo", "context", "workflow_ref"]
+      ready_role_arn     = "arn:aws:iam::123456789012:role/example-test"
+    },
+  ]
+}
+
+run "repository_customization" {
+  command = plan
+  providers = {
+    github = github.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = github_actions_repository_oidc_subject_claim_customization_template.workflow.repository == "example-repo"
+    error_message = "The GitHub provider resource should receive the repository name."
+  }
+
+  assert {
+    condition     = !github_actions_repository_oidc_subject_claim_customization_template.workflow.use_default
+    error_message = "The repository must opt into its custom subject template."
+  }
+
+  assert {
+    condition     = tolist(github_actions_repository_oidc_subject_claim_customization_template.workflow.include_claim_keys) == tolist(["repo", "context", "workflow_ref"])
+    error_message = "The customization should apply the standardized ordered claims."
+  }
+
+  assert {
+    condition = tolist(terraform_data.role_trust_policies_ready.input) == tolist([
+      "arn:aws:iam::123456789012:role/example-deploy",
+      "arn:aws:iam::123456789012:role/example-test",
+    ])
+    error_message = "The dependency barrier should contain every sorted role ARN."
+  }
+
+  assert {
+    condition     = output.github_repository == "example-org/example-repo"
+    error_message = "The module should output the full repository name."
+  }
+}
+
+run "reject_empty_contracts" {
+  command = plan
+  providers = {
+    github = github.mock
+  }
+
+  variables {
+    role_configurations = []
+  }
+
+  expect_failures = [var.role_configurations]
+}
+
+run "reject_mixed_repositories" {
+  command = plan
+  providers = {
+    github = github.mock
+  }
+
+  variables {
+    role_configurations = [
+      {
+        github_repository  = "example-org/example-repo"
+        include_claim_keys = ["repo", "context", "workflow_ref"]
+        ready_role_arn     = "arn:aws:iam::123456789012:role/example-deploy"
+      },
+      {
+        github_repository  = "example-org/other-repo"
+        include_claim_keys = ["repo", "context", "workflow_ref"]
+        ready_role_arn     = "arn:aws:iam::123456789012:role/example-test"
+      },
+    ]
+  }
+
+  expect_failures = [var.role_configurations]
+}
+
+run "pass_through_claim_keys" {
+  command = plan
+  providers = {
+    github = github.mock
+  }
+
+  variables {
+    role_configurations = [{
+      github_repository  = "example-org/example-repo"
+      include_claim_keys = ["repo", "job_workflow_ref"]
+      ready_role_arn     = "arn:aws:iam::123456789012:role/example-deploy"
+    }]
+  }
+
+  assert {
+    condition     = tolist(github_actions_repository_oidc_subject_claim_customization_template.workflow.include_claim_keys) == tolist(["repo", "job_workflow_ref"])
+    error_message = "The repository customization should pass through the role contract's ordered claim keys."
+  }
+}
+
+run "reject_mixed_claim_keys" {
+  command = plan
+  providers = {
+    github = github.mock
+  }
+
+  variables {
+    role_configurations = [
+      {
+        github_repository  = "example-org/example-repo"
+        include_claim_keys = ["repo", "context", "workflow_ref"]
+        ready_role_arn     = "arn:aws:iam::123456789012:role/example-deploy"
+      },
+      {
+        github_repository  = "example-org/example-repo"
+        include_claim_keys = ["repo", "job_workflow_ref"]
+        ready_role_arn     = "arn:aws:iam::123456789012:role/example-test"
+      },
+    ]
+  }
+
+  expect_failures = [var.role_configurations]
+}

--- a/modules/internal/repo-oidc-customization/outputs.tf
+++ b/modules/internal/repo-oidc-customization/outputs.tf
@@ -1,0 +1,14 @@
+output "github_repository" {
+  description = "Repository whose OIDC subject template is customized."
+  value       = local.github_repository
+}
+
+output "include_claim_keys" {
+  description = "Ordered claims included in the customized OIDC subject."
+  value       = github_actions_repository_oidc_subject_claim_customization_template.workflow.include_claim_keys
+}
+
+output "customization_id" {
+  description = "GitHub repository OIDC customization resource identifier."
+  value       = github_actions_repository_oidc_subject_claim_customization_template.workflow.id
+}

--- a/modules/internal/repo-oidc-customization/providers.tf
+++ b/modules/internal/repo-oidc-customization/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/internal/repo-oidc-customization/tests/integration/main.tf
+++ b/modules/internal/repo-oidc-customization/tests/integration/main.tf
@@ -1,0 +1,32 @@
+module "role" {
+  source = "../../../github-actions-aws-role"
+
+  role_name                = "contract-test"
+  github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+  github_repository        = "example-org/example-repo"
+  trusted_workflows = [{
+    workflow_filename = "deploy.yml"
+    context = {
+      type  = "branch"
+      value = "main"
+    }
+  }]
+}
+
+module "repository_customization" {
+  source = "../.."
+
+  role_configurations = [module.role.repository_oidc_configuration]
+}
+
+output "role_repository" {
+  value = module.role.repository_oidc_configuration.github_repository
+}
+
+output "customization_repository" {
+  value = module.repository_customization.github_repository
+}
+
+output "include_claim_keys" {
+  value = module.repository_customization.include_claim_keys
+}

--- a/modules/internal/repo-oidc-customization/tests/integration/main.tf
+++ b/modules/internal/repo-oidc-customization/tests/integration/main.tf
@@ -2,6 +2,7 @@ module "role" {
   source = "../../../github-actions-aws-role"
 
   role_name                = "contract-test"
+  role_secret_name         = "AWS_CONTRACT_TEST_ROLE_ARN"
   github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
   github_repository        = "example-org/example-repo"
   trusted_workflows = [{

--- a/modules/internal/repo-oidc-customization/tests/integration/providers.tf
+++ b/modules/internal/repo-oidc-customization/tests/integration/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/internal/repo-oidc-customization/variables.tf
+++ b/modules/internal/repo-oidc-customization/variables.tf
@@ -1,0 +1,49 @@
+variable "role_configurations" {
+  description = "Repository OIDC contracts output by every github-actions-aws-role module for this repository."
+  type = list(object({
+    github_repository  = string
+    include_claim_keys = list(string)
+    ready_role_arn     = string
+  }))
+
+  validation {
+    condition     = length(var.role_configurations) > 0
+    error_message = "role_configurations must contain at least one role contract."
+  }
+
+  validation {
+    condition = length(var.role_configurations) == 0 || (
+      length(distinct([for configuration in var.role_configurations : configuration.github_repository])) == 1 &&
+      alltrue([
+        for configuration in var.role_configurations :
+        can(regex("^[^/[:space:]]+/[^/[:space:]]+$", configuration.github_repository))
+      ])
+    )
+    error_message = "All role configurations must use the same valid owner/repo repository."
+  }
+
+  validation {
+    condition = length(var.role_configurations) == 0 || alltrue([
+      for configuration in var.role_configurations :
+      length(configuration.include_claim_keys) > 0 &&
+      alltrue([for claim_key in configuration.include_claim_keys : can(regex("^[0-9A-Za-z_]+$", claim_key))])
+    ])
+    error_message = "Every role configuration must contain at least one valid OIDC claim key."
+  }
+
+  validation {
+    condition = length(var.role_configurations) == 0 || alltrue([
+      for configuration in var.role_configurations :
+      jsonencode(configuration.include_claim_keys) == jsonencode(var.role_configurations[0].include_claim_keys)
+    ])
+    error_message = "All role configurations must use the same ordered OIDC claim keys."
+  }
+
+  validation {
+    condition = alltrue([
+      for configuration in var.role_configurations :
+      can(regex("^arn:[^:]+:iam::[0-9]{12}:role/.+", configuration.ready_role_arn))
+    ])
+    error_message = "Every role configuration must contain a valid ready_role_arn."
+  }
+}


### PR DESCRIPTION
This PR includes several new modules, as well as a start to a testing workflow. The testing workflow probably won't work correctly because this is coming from a personal fork (after some issues with token permissions in the `gh` CLI) -- I figure I'll use a follow-up PR to fix any issues with testing.

There includes 2 new modules for reuse in other projects, plus a bootstrap module that will be used to deploy the roles needed for testing here. The new modules are:

* `github-actions-aws-role`: Create a role that can be assumed by OIDC from a GitHub Actions Workflow
* `repo-oidc-customization`: Customize the OIDC subject claims provided by GitHub Actions for a repo.

These are separate because you'll need repo customization once per repo, and you may need multiple roles per repo.

Assisted-by: Codex.app:GPT-5.6-Sol