### PR TITLE
Add deploy permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,6 +92,9 @@ jobs:
             if ! TF_DATA_DIR="$data_dir" tofu -chdir="$module" init -backend=false -no-color; then
               result="Initialization failed"
               failed_modules+=("$module")
+            elif ! TF_DATA_DIR="$data_dir" tofu -chdir="$module" validate -no-color; then
+              result="Validation failed"
+              failed_modules+=("$module")
             elif ! TF_DATA_DIR="$data_dir" tofu -chdir="$module" test -no-color; then
               result="Tests failed"
               failed_modules+=("$module")

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
       - "bootstrap/**"
       - "deploy-permissions/**"
       - "modules/**"
+      - "tests/contracts/**"
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - "bootstrap/**"
       - "deploy-permissions/**"
       - "modules/**"
+      - "tests/contracts/**"
   workflow_dispatch:
 
 env:
@@ -61,6 +63,9 @@ jobs:
         modules/internal/github-actions-aws-role
         modules/internal/repo-oidc-customization
         modules/tfstate-aws-backend
+        tests/contracts/github-oidc
+        tests/contracts/internal-github-actions-aws-role
+        tests/contracts/tfstate-aws-backend
 
     steps:
       - name: Check out repository

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -25,25 +25,31 @@ Future live tests will use a two-account design:
    root account.
 2. OpenTofu's S3 backend will use that root-account identity to read, write,
    and lock test state in a root-account state bucket.
-3. The AWS provider will use the root role to assume a separate deployment role
-   in the sandbox account.
-4. The sandbox deployment role will receive the generated permissions needed
-   to create and destroy test resources in the sandbox account.
+3. The AWS provider will use the root role to assume the persistent deployment
+   role for the fixture type being tested in the sandbox account.
+4. Each fixture deployment role will receive only the generated permissions
+   needed to create and destroy that fixture type in the sandbox account.
 
 The S3 backend and AWS provider authenticate independently. Live test roots
 will therefore configure the backend to use the workflow's ambient root-role
 credentials while configuring the AWS provider with an `assume_role` block for
-the sandbox deployment role. The sandbox role will not need access to the root
-state bucket.
+the appropriate fixture deployment role. Fixture roles will not need access to
+the root state bucket.
 
 When live tests are introduced, this bootstrap is expected to grow to:
 
-- create the sandbox deployment role;
-- allow only `eco-infra-infra-tests` to assume that role;
+- create one persistent sandbox deployment role for each live fixture type;
+- allow only `eco-infra-infra-tests` to assume those roles;
 - grant the root role access to the test-state bucket and permission to assume
-  the exact sandbox role; and
-- attach narrowly scoped policies from `deploy-permissions/` to the sandbox
-  role for the resources under test.
+  the exact, enumerated fixture-role ARNs; and
+- attach the matching `all` policy from `deploy-permissions/` to each fixture
+  role.
+
+Workflow runs will reuse the persistent role for their fixture type while
+keeping resource names and state isolated by pull request and run. Workflows
+will not create or destroy deployment roles dynamically; the root role will
+therefore need permission to assume the enumerated roles, but not permission to
+manage IAM roles in the sandbox account.
 
 The existing `deploy-permissions/tfstate-aws-backend` module manages permissions
 for deploying the bucket itself; it does not provide the runtime S3 object
@@ -97,9 +103,10 @@ provider and manage the test IAM role. Configure the GitHub provider with a
 token that can manage Actions secrets and the repository OIDC customization,
 for example through the `GITHUB_TOKEN` environment variable.
 
-The test role intentionally has no workload permissions. Add permissions from
-the matching modules under `deploy-permissions/` only when a CI test begins
-creating and destroying a narrowly scoped AWS fixture.
+The test role intentionally has no workload permissions. Add a persistent
+fixture role with permissions from the matching module under
+`deploy-permissions/` only when the live suite begins creating and destroying
+that fixture type.
 
 ## Enable the tests workflow
 

--- a/deploy-permissions/README.md
+++ b/deploy-permissions/README.md
@@ -1,0 +1,54 @@
+# Deploy Permissions
+
+This directory contains Terraform modules that publish deploy-time permissions
+for the infrastructure modules in `modules/`.
+
+AWS resource modules mirror `modules/` one-for-one:
+
+- `modules/foo` pairs with `deploy-permissions/foo`
+
+Modules that only configure another provider do not receive an AWS IAM
+deploy-permissions companion. For example,
+`modules/internal/repo-oidc-customization` uses GitHub API authorization.
+
+Each deploy-permissions module exposes the same five outputs:
+
+- `plan`
+- `create`
+- `update`
+- `destroy`
+- `all`
+
+Each output is an IAM policy document JSON string intended to be attached
+directly to a role or wrapped in an `aws_iam_policy` resource, for example:
+
+```hcl
+module "backend_permissions" {
+  source = "../../deploy-permissions/tfstate-aws-backend"
+
+  bucket_name = "example-tfstate-bucket"
+}
+
+resource "aws_iam_policy" "backend_create" {
+  name   = "backend-create"
+  policy = module.backend_permissions.create
+}
+```
+
+The outputs are scoped by lifecycle phase:
+
+- `plan`: read and discovery permissions only
+- `create`: `plan` plus create-time mutation permissions
+- `update`: `plan` plus update-time mutation permissions
+- `destroy`: `plan` plus teardown permissions
+- `all`: the deduplicated union of `create`, `update`, and `destroy`
+
+Some infrastructure modules may intentionally use controls such as
+`prevent_destroy`. The matching deploy-permissions module should still publish a
+`destroy` policy so operators have a documented, explicit permission set for
+controlled teardown after configuration changes or intentional lifecycle
+overrides.
+
+These modules describe permissions needed to deploy and manage infrastructure.
+They do not automatically describe the runtime permissions required to use the
+resulting resources after they have been created.

--- a/deploy-permissions/github-oidc/README.md
+++ b/deploy-permissions/github-oidc/README.md
@@ -1,0 +1,40 @@
+# github-oidc deploy permissions
+
+This module emits IAM policy document JSON for deploying and managing the
+paired `modules/github-oidc` module.
+
+## Input
+
+This module has no inputs.
+
+## Outputs
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `plan` | `string` | IAM policy JSON for read and discovery access |
+| `create` | `string` | IAM policy JSON for creating the GitHub OIDC provider |
+| `update` | `string` | IAM policy JSON for updating the GitHub OIDC provider configuration |
+| `destroy` | `string` | IAM policy JSON for deleting the GitHub OIDC provider |
+| `all` | `string` | IAM policy JSON containing the deduplicated union of all lifecycle permissions |
+
+## Scope
+
+The generated policies are intentionally limited to deploy-time management of
+the account's GitHub Actions OIDC provider at:
+
+- `arn:${partition}:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com`
+
+Lifecycle access is split as follows:
+
+- `plan`: `iam:ListOpenIDConnectProviders` on `*` plus
+  `iam:GetOpenIDConnectProvider` on the exact provider ARN
+- `create`: `plan` plus `iam:CreateOpenIDConnectProvider`
+- `update`: `plan` plus `iam:AddClientIDToOpenIDConnectProvider`,
+  `iam:RemoveClientIDFromOpenIDConnectProvider`, and
+  `iam:UpdateOpenIDConnectProviderThumbprint`
+- `destroy`: `plan` plus `iam:DeleteOpenIDConnectProvider`
+- `all`: union of `create`, `update`, and `destroy`
+
+These policies cover deployment and lifecycle management only. They do not
+grant runtime permissions for GitHub Actions or define IAM role trust policies
+that use this OIDC provider.

--- a/deploy-permissions/github-oidc/README.md
+++ b/deploy-permissions/github-oidc/README.md
@@ -24,6 +24,9 @@ the account's GitHub Actions OIDC provider at:
 
 - `arn:${partition}:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com`
 
+Since this module will only deploy into the user's account, the ARN can be
+derived from the current account ID and partition.
+
 Lifecycle access is split as follows:
 
 - `plan`: `iam:ListOpenIDConnectProviders` on `*` plus

--- a/deploy-permissions/github-oidc/main.tf
+++ b/deploy-permissions/github-oidc/main.tf
@@ -1,0 +1,104 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  provider_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+
+  statements = {
+    discovery = {
+      Sid    = "GitHubOidcDiscovery"
+      Effect = "Allow"
+      Action = [
+        "iam:ListOpenIDConnectProviders",
+      ]
+      Resource = ["*"]
+    }
+
+    provider_read = {
+      Sid    = "GitHubOidcRead"
+      Effect = "Allow"
+      Action = [
+        "iam:GetOpenIDConnectProvider",
+      ]
+      Resource = [local.provider_arn]
+    }
+
+    provider_create = {
+      Sid    = "GitHubOidcCreate"
+      Effect = "Allow"
+      Action = [
+        "iam:CreateOpenIDConnectProvider",
+      ]
+      Resource = [local.provider_arn]
+    }
+
+    provider_update = {
+      Sid    = "GitHubOidcUpdate"
+      Effect = "Allow"
+      Action = [
+        "iam:AddClientIDToOpenIDConnectProvider",
+        "iam:RemoveClientIDFromOpenIDConnectProvider",
+        "iam:UpdateOpenIDConnectProviderThumbprint",
+      ]
+      Resource = [local.provider_arn]
+    }
+
+    provider_destroy = {
+      Sid    = "GitHubOidcDestroy"
+      Effect = "Allow"
+      Action = [
+        "iam:DeleteOpenIDConnectProvider",
+      ]
+      Resource = [local.provider_arn]
+    }
+  }
+
+  policies = {
+    plan = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.provider_read,
+      ]
+    }
+
+    create = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.provider_read,
+        local.statements.provider_create,
+      ]
+    }
+
+    update = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.provider_read,
+        local.statements.provider_update,
+      ]
+    }
+
+    destroy = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.provider_read,
+        local.statements.provider_destroy,
+      ]
+    }
+
+    all = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.provider_read,
+        local.statements.provider_create,
+        local.statements.provider_update,
+        local.statements.provider_destroy,
+      ]
+    }
+  }
+}

--- a/deploy-permissions/github-oidc/outputs.tf
+++ b/deploy-permissions/github-oidc/outputs.tf
@@ -1,0 +1,24 @@
+output "plan" {
+  description = "IAM policy JSON for planning GitHub OIDC provider changes."
+  value       = jsonencode(local.policies.plan)
+}
+
+output "create" {
+  description = "IAM policy JSON for creating the GitHub OIDC provider."
+  value       = jsonencode(local.policies.create)
+}
+
+output "update" {
+  description = "IAM policy JSON for updating the GitHub OIDC provider."
+  value       = jsonencode(local.policies.update)
+}
+
+output "destroy" {
+  description = "IAM policy JSON for destroying the GitHub OIDC provider."
+  value       = jsonencode(local.policies.destroy)
+}
+
+output "all" {
+  description = "IAM policy JSON for all GitHub OIDC provider lifecycle operations."
+  value       = jsonencode(local.policies.all)
+}

--- a/deploy-permissions/github-oidc/providers.tf
+++ b/deploy-permissions/github-oidc/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/deploy-permissions/internal/github-actions-aws-role/README.md
+++ b/deploy-permissions/internal/github-actions-aws-role/README.md
@@ -1,0 +1,42 @@
+# github-actions-aws-role deploy permissions
+
+Produces IAM policy JSON for deploying the paired
+`modules/internal/github-actions-aws-role` module. It follows the repository's
+standard lifecycle outputs: `plan`, `create`, `update`, `destroy`, and `all`.
+
+## Usage
+
+```hcl
+module "role_deploy_permissions" {
+  source = "github.com/omsf-eco-infra/eco-infra-infra//deploy-permissions/internal/github-actions-aws-role"
+
+  role_name = "example-deployer"
+  managed_policy_arns = {
+    shared-read = aws_iam_policy.shared_read.arn
+  }
+}
+```
+
+Each output is a JSON string suitable for an IAM policy resource. Pass the same
+`role_name`, `managed_policy_arns`, and `force_detach_policies` values to this
+module and the paired infrastructure module.
+
+## Scoping
+
+- Role operations target the exact role ARN in the current AWS account and
+  partition.
+- Managed policy attachment and normal detachment are restricted by
+  `iam:PolicyARN` to configured managed policies.
+- If `force_detach_policies` is true, destroy/update permissions allow
+  unrestricted `DetachRolePolicy` only on that exact role. This is required to
+  remove policies attached outside Terraform before role deletion.
+- The module does not grant `iam:PassRole` or workload runtime permissions.
+
+The paired infrastructure module also publishes the role ARN as a GitHub
+Actions repository secret. These AWS IAM policies do not authorize that GitHub
+API operation; configure the GitHub provider separately with permission to
+manage Actions secrets in the target repository.
+
+There is no AWS deploy-permissions companion for
+`repo-oidc-customization`; that module requires GitHub API authorization rather
+than AWS IAM authorization.

--- a/deploy-permissions/internal/github-actions-aws-role/main.tf
+++ b/deploy-permissions/internal/github-actions-aws-role/main.tf
@@ -1,0 +1,159 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  role_arn            = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
+  managed_policy_arns = sort(values(var.managed_policy_arns))
+
+  statements = {
+    role_read = {
+      Sid    = "GitHubActionsRoleRead"
+      Effect = "Allow"
+      Action = [
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListRolePolicies",
+        "iam:ListRoleTags",
+      ]
+      Resource = [local.role_arn]
+    }
+
+    role_create = {
+      Sid    = "GitHubActionsRoleCreate"
+      Effect = "Allow"
+      Action = [
+        "iam:CreateRole",
+        "iam:TagRole",
+      ]
+      Resource = [local.role_arn]
+    }
+
+    role_update = {
+      Sid    = "GitHubActionsRoleUpdate"
+      Effect = "Allow"
+      Action = [
+        "iam:TagRole",
+        "iam:UntagRole",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:UpdateRole",
+        "iam:UpdateRoleDescription",
+      ]
+      Resource = [local.role_arn]
+    }
+
+    inline_policy_upsert = {
+      Sid      = "GitHubActionsInlinePolicyUpsert"
+      Effect   = "Allow"
+      Action   = ["iam:PutRolePolicy"]
+      Resource = [local.role_arn]
+    }
+
+    inline_policy_delete = {
+      Sid      = "GitHubActionsInlinePolicyDelete"
+      Effect   = "Allow"
+      Action   = ["iam:DeleteRolePolicy"]
+      Resource = [local.role_arn]
+    }
+
+    managed_policy_attach = {
+      Sid      = "GitHubActionsManagedPolicyAttach"
+      Effect   = "Allow"
+      Action   = ["iam:AttachRolePolicy"]
+      Resource = [local.role_arn]
+      Condition = {
+        ArnEquals = {
+          "iam:PolicyARN" = local.managed_policy_arns
+        }
+      }
+    }
+
+    managed_policy_detach_scoped = {
+      Sid      = "GitHubActionsManagedPolicyDetach"
+      Effect   = "Allow"
+      Action   = ["iam:DetachRolePolicy"]
+      Resource = [local.role_arn]
+      Condition = {
+        ArnEquals = {
+          "iam:PolicyARN" = local.managed_policy_arns
+        }
+      }
+    }
+
+    managed_policy_detach_all = {
+      Sid      = "GitHubActionsManagedPolicyForceDetach"
+      Effect   = "Allow"
+      Action   = ["iam:DetachRolePolicy"]
+      Resource = [local.role_arn]
+    }
+
+    role_destroy = {
+      Sid      = "GitHubActionsRoleDestroy"
+      Effect   = "Allow"
+      Action   = ["iam:DeleteRole"]
+      Resource = [local.role_arn]
+    }
+  }
+
+  managed_policy_attach_statements = length(local.managed_policy_arns) > 0 ? [local.statements.managed_policy_attach] : []
+  managed_policy_detach_statements = concat(
+    var.force_detach_policies ? [local.statements.managed_policy_detach_all] : [],
+    !var.force_detach_policies && length(local.managed_policy_arns) > 0 ? [local.statements.managed_policy_detach_scoped] : [],
+  )
+
+  policy_statements = {
+    plan = [
+      local.statements.role_read,
+    ]
+
+    create = concat(
+      [
+        local.statements.role_read,
+        local.statements.role_create,
+        local.statements.inline_policy_upsert,
+      ],
+      local.managed_policy_attach_statements,
+    )
+
+    update = concat(
+      [
+        local.statements.role_read,
+        local.statements.role_update,
+        local.statements.inline_policy_upsert,
+        local.statements.inline_policy_delete,
+      ],
+      local.managed_policy_attach_statements,
+      local.managed_policy_detach_statements,
+    )
+
+    destroy = concat(
+      [
+        local.statements.role_read,
+        local.statements.inline_policy_delete,
+      ],
+      local.managed_policy_detach_statements,
+      [local.statements.role_destroy],
+    )
+
+    all = concat(
+      [
+        local.statements.role_read,
+        local.statements.role_create,
+        local.statements.role_update,
+        local.statements.inline_policy_upsert,
+        local.statements.inline_policy_delete,
+      ],
+      local.managed_policy_attach_statements,
+      local.managed_policy_detach_statements,
+      [local.statements.role_destroy],
+    )
+  }
+
+  policies = {
+    for lifecycle, statements in local.policy_statements : lifecycle => {
+      Version   = "2012-10-17"
+      Statement = statements
+    }
+  }
+}

--- a/deploy-permissions/internal/github-actions-aws-role/outputs.tf
+++ b/deploy-permissions/internal/github-actions-aws-role/outputs.tf
@@ -1,0 +1,24 @@
+output "plan" {
+  description = "IAM policy JSON for planning GitHub Actions role changes."
+  value       = jsonencode(local.policies.plan)
+}
+
+output "create" {
+  description = "IAM policy JSON for creating the GitHub Actions role and its policies."
+  value       = jsonencode(local.policies.create)
+}
+
+output "update" {
+  description = "IAM policy JSON for updating the GitHub Actions role and its policies."
+  value       = jsonencode(local.policies.update)
+}
+
+output "destroy" {
+  description = "IAM policy JSON for destroying the GitHub Actions role and its policies."
+  value       = jsonencode(local.policies.destroy)
+}
+
+output "all" {
+  description = "IAM policy JSON for all GitHub Actions role lifecycle operations."
+  value       = jsonencode(local.policies.all)
+}

--- a/deploy-permissions/internal/github-actions-aws-role/providers.tf
+++ b/deploy-permissions/internal/github-actions-aws-role/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/deploy-permissions/internal/github-actions-aws-role/variables.tf
+++ b/deploy-permissions/internal/github-actions-aws-role/variables.tf
@@ -1,0 +1,29 @@
+variable "role_name" {
+  description = "Name of the IAM role managed by the paired github-actions-aws-role module."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.role_name)) > 0 && length(var.role_name) <= 64
+    error_message = "role_name must be non-empty and no longer than 64 characters."
+  }
+}
+
+variable "managed_policy_arns" {
+  description = "Managed policy ARNs attached by the paired role module."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for name, arn in var.managed_policy_arns :
+      length(trimspace(name)) > 0 && can(regex("^arn:[^:]+:iam::([0-9]{12}|aws):policy/.+", arn))
+    ])
+    error_message = "managed_policy_arns keys must be non-empty and values must be IAM managed policy ARNs."
+  }
+}
+
+variable "force_detach_policies" {
+  description = "Allow detaching any managed policy from the exact role during destruction."
+  type        = bool
+  default     = false
+}

--- a/deploy-permissions/tfstate-aws-backend/README.md
+++ b/deploy-permissions/tfstate-aws-backend/README.md
@@ -1,0 +1,40 @@
+# tfstate-aws-backend deploy permissions
+
+This module emits IAM policy document JSON for deploying and managing the
+paired `modules/tfstate-aws-backend` module.
+
+## Input
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `bucket_name` | `string` | Name of the S3 bucket managed by the paired infra module |
+
+## Outputs
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `plan` | `string` | IAM policy JSON for read and discovery access |
+| `create` | `string` | IAM policy JSON for creating the bucket and configuring it |
+| `update` | `string` | IAM policy JSON for updating bucket configuration |
+| `destroy` | `string` | IAM policy JSON for emptying and deleting the bucket |
+| `all` | `string` | IAM policy JSON containing the deduplicated union of all lifecycle permissions |
+
+## Scope
+
+The generated policies are intentionally limited to deploy-time management of
+the backend bucket:
+
+- Global discovery: `s3:ListAllMyBuckets`
+- Bucket reads: `s3:ListBucket`, `s3:GetBucketLocation`,
+  `s3:GetBucketVersioning`, `s3:GetEncryptionConfiguration`,
+  `s3:GetBucketPublicAccessBlock`, and `s3:GetLifecycleConfiguration`
+- Bucket mutation: `s3:CreateBucket`, `s3:PutBucketVersioning`,
+  `s3:PutEncryptionConfiguration`, `s3:PutBucketPublicAccessBlock`, and
+  `s3:PutLifecycleConfiguration`
+- Destroy cleanup: `s3:DeleteBucket`, `s3:ListBucketVersions`,
+  `s3:DeleteObject`, and `s3:DeleteObjectVersion`
+
+`destroy` includes cleanup permissions for bucket objects and versions so a
+populated state bucket can be removed during an intentional teardown workflow.
+This module does not include the runtime permissions needed to use the bucket as
+an OpenTofu or Terraform backend after it exists.

--- a/deploy-permissions/tfstate-aws-backend/main.tf
+++ b/deploy-permissions/tfstate-aws-backend/main.tf
@@ -1,0 +1,122 @@
+locals {
+  bucket_arn = "arn:aws:s3:::${var.bucket_name}"
+  object_arn = "${local.bucket_arn}/*"
+
+  statements = {
+    discovery = {
+      Sid    = "S3BucketDiscovery"
+      Effect = "Allow"
+      Action = [
+        "s3:ListAllMyBuckets",
+      ]
+      Resource = ["*"]
+    }
+
+    bucket_read = {
+      Sid    = "TfstateBucketRead"
+      Effect = "Allow"
+      Action = [
+        "s3:GetBucketLocation",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketVersioning",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:ListBucket",
+      ]
+      Resource = [local.bucket_arn]
+    }
+
+    bucket_create = {
+      Sid    = "TfstateBucketCreate"
+      Effect = "Allow"
+      Action = [
+        "s3:CreateBucket",
+      ]
+      Resource = [local.bucket_arn]
+    }
+
+    bucket_mutation = {
+      Sid    = "TfstateBucketMutation"
+      Effect = "Allow"
+      Action = [
+        "s3:PutBucketPublicAccessBlock",
+        "s3:PutBucketVersioning",
+        "s3:PutEncryptionConfiguration",
+        "s3:PutLifecycleConfiguration",
+      ]
+      Resource = [local.bucket_arn]
+    }
+
+    object_cleanup = {
+      Sid    = "TfstateObjectCleanup"
+      Effect = "Allow"
+      Action = [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+      ]
+      Resource = [local.object_arn]
+    }
+
+    bucket_destroy = {
+      Sid    = "TfstateBucketDestroy"
+      Effect = "Allow"
+      Action = [
+        "s3:DeleteBucket",
+        "s3:ListBucketVersions",
+      ]
+      Resource = [local.bucket_arn]
+    }
+  }
+
+  policies = {
+    plan = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.bucket_read,
+      ]
+    }
+
+    create = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.bucket_read,
+        local.statements.bucket_create,
+        local.statements.bucket_mutation,
+      ]
+    }
+
+    update = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.bucket_read,
+        local.statements.bucket_mutation,
+      ]
+    }
+
+    destroy = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.bucket_read,
+        local.statements.bucket_mutation,
+        local.statements.object_cleanup,
+        local.statements.bucket_destroy,
+      ]
+    }
+
+    all = {
+      Version = "2012-10-17"
+      Statement = [
+        local.statements.discovery,
+        local.statements.bucket_read,
+        local.statements.bucket_create,
+        local.statements.bucket_mutation,
+        local.statements.object_cleanup,
+        local.statements.bucket_destroy,
+      ]
+    }
+  }
+}

--- a/deploy-permissions/tfstate-aws-backend/outputs.tf
+++ b/deploy-permissions/tfstate-aws-backend/outputs.tf
@@ -1,0 +1,24 @@
+output "plan" {
+  description = "IAM policy JSON for planning tfstate backend bucket changes."
+  value       = jsonencode(local.policies.plan)
+}
+
+output "create" {
+  description = "IAM policy JSON for creating the tfstate backend bucket."
+  value       = jsonencode(local.policies.create)
+}
+
+output "update" {
+  description = "IAM policy JSON for updating the tfstate backend bucket."
+  value       = jsonencode(local.policies.update)
+}
+
+output "destroy" {
+  description = "IAM policy JSON for destroying the tfstate backend bucket."
+  value       = jsonencode(local.policies.destroy)
+}
+
+output "all" {
+  description = "IAM policy JSON for all tfstate backend bucket lifecycle operations."
+  value       = jsonencode(local.policies.all)
+}

--- a/deploy-permissions/tfstate-aws-backend/variables.tf
+++ b/deploy-permissions/tfstate-aws-backend/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket managed by the tfstate backend module."
+}

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -1,0 +1,68 @@
+# Contract tests
+
+The tests in this directory exercise modules as an external consumer would use
+them. Each contract root composes an infrastructure module with its matching
+module under `deploy-permissions/` and passes the same resource identifiers and
+relevant lifecycle settings to both.
+
+This is also the primary location for testing deploy-permissions contracts.
+Deploy-permissions modules do not have committed module-local `.tftest.hcl`
+files. Their generated IAM policies are tested here alongside the
+infrastructure modules those policies are intended to deploy.
+
+## Contract tests versus module tests
+
+Module-local tests under `modules/` can inspect a module's internal resources.
+They verify details such as encryption, lifecycle settings, trust policies,
+resource selection, outputs, and input validation.
+
+Contract tests use child modules through their public interfaces. They verify
+that independently maintained modules can be composed correctly, without
+depending on the child modules' internal resource addresses.
+
+| Module-local tests | Contract tests |
+| --- | --- |
+| Exercise one module | Compose infrastructure and deploy-permissions modules |
+| Inspect internal resources | Use public inputs and outputs |
+| Verify resource configuration | Verify cross-module interface compatibility |
+| Catch implementation regressions | Catch mismatched identifiers, settings, and policy scope |
+
+The two levels are complementary. For example, the
+`tfstate-aws-backend` module test verifies bucket versioning and encryption,
+while its contract test verifies that the companion policy targets that same
+bucket and provides the expected lifecycle permissions.
+
+## Deploy-permissions contract
+
+Each applicable contract root should verify that:
+
+- the infrastructure and deploy-permissions modules accept the same resource
+  identifiers and shared lifecycle settings;
+- the composed configuration initializes and plans successfully;
+- generated statements target the exact resource ARN, except where an AWS API
+  requires a discovery action on all resources;
+- `plan`, `create`, `update`, and `destroy` contain the appropriate lifecycle
+  operations without unrelated mutations;
+- `all` is the deduplicated union of `create`, `update`, and `destroy`; and
+- important shared input failures remain actionable at the consumer boundary.
+
+Live lifecycle tests will later exercise these policies against AWS. The
+contract tests remain the fast, credential-free check for policy generation
+and module composition.
+
+Modules that configure only a non-AWS provider do not need an AWS
+deploy-permissions companion. Their cross-module contracts may still be tested
+elsewhere when they publish values consumed by another module.
+
+## Running the tests
+
+Run a contract root in the same way as any other OpenTofu test root:
+
+```console
+tofu -chdir=tests/contracts/github-oidc init -backend=false
+tofu -chdir=tests/contracts/github-oidc test
+```
+
+The fast-test workflow runs every committed contract root. Provider lock files
+created while running these reusable test roots locally are ignored and should
+not be committed.

--- a/tests/contracts/github-oidc/main.tf
+++ b/tests/contracts/github-oidc/main.tf
@@ -1,0 +1,33 @@
+module "infrastructure" {
+  source = "../../../modules/github-oidc"
+
+  prevent_destroy = false
+}
+
+module "deploy_permissions" {
+  source = "../../../deploy-permissions/github-oidc"
+}
+
+output "github_oidc_provider_arn" {
+  value = module.infrastructure.github_oidc_provider_arn
+}
+
+output "permissions_plan" {
+  value = module.deploy_permissions.plan
+}
+
+output "permissions_create" {
+  value = module.deploy_permissions.create
+}
+
+output "permissions_update" {
+  value = module.deploy_permissions.update
+}
+
+output "permissions_destroy" {
+  value = module.deploy_permissions.destroy
+}
+
+output "permissions_all" {
+  value = module.deploy_permissions.all
+}

--- a/tests/contracts/github-oidc/main.tftest.hcl
+++ b/tests/contracts/github-oidc/main.tftest.hcl
@@ -1,0 +1,84 @@
+mock_provider "aws" {
+  alias = "mock"
+}
+
+override_data {
+  target = module.deploy_permissions.data.aws_caller_identity.current
+  values = {
+    account_id = "123456789012"
+  }
+}
+
+override_resource {
+  target = module.infrastructure.aws_iam_openid_connect_provider.github_destroyable
+  values = {
+    arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+  }
+}
+
+override_data {
+  target = module.deploy_permissions.data.aws_partition.current
+  values = {
+    partition = "aws"
+  }
+}
+
+run "resource_and_permissions_contract" {
+  command = plan
+
+  providers = {
+    aws = aws.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = output.github_oidc_provider_arn == "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+    error_message = "The disposable infrastructure fixture should expose the managed GitHub Actions OIDC provider ARN."
+  }
+
+  assert {
+    condition = alltrue([
+      for statement in jsondecode(output.permissions_all).Statement :
+      statement.Resource == (statement.Sid == "GitHubOidcDiscovery" ? ["*"] : ["arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"])
+    ])
+    error_message = "Provider operations should target the exact GitHub OIDC provider ARN; only discovery may target all resources."
+  }
+
+  assert {
+    condition = (
+      contains(flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]), "iam:CreateOpenIDConnectProvider") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]), "iam:DeleteOpenIDConnectProvider") &&
+      contains(flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]), "iam:UpdateOpenIDConnectProviderThumbprint") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]), "iam:CreateOpenIDConnectProvider") &&
+      contains(flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]), "iam:DeleteOpenIDConnectProvider") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]), "iam:CreateOpenIDConnectProvider")
+    )
+    error_message = "Create, update, and destroy policies should contain only their lifecycle mutations."
+  }
+
+  assert {
+    condition = (
+      length(distinct([for statement in jsondecode(output.permissions_all).Statement : statement.Sid])) == length(jsondecode(output.permissions_all).Statement) &&
+      length(setsubtract(
+        toset(concat(
+          flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]),
+        )),
+        toset(flatten([for statement in jsondecode(output.permissions_all).Statement : statement.Action])),
+      )) == 0 &&
+      length(setsubtract(
+        toset(flatten([for statement in jsondecode(output.permissions_all).Statement : statement.Action])),
+        toset(concat(
+          flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]),
+        )),
+      )) == 0
+    )
+    error_message = "The all policy should be the deduplicated union of create, update, and destroy permissions."
+  }
+}

--- a/tests/contracts/github-oidc/providers.tf
+++ b/tests/contracts/github-oidc/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/tests/contracts/internal-github-actions-aws-role/main.tf
+++ b/tests/contracts/internal-github-actions-aws-role/main.tf
@@ -1,0 +1,71 @@
+variable "role_name" {
+  type        = string
+  description = "Role name shared by the infrastructure and deploy-permissions modules."
+  default     = "contract-test-role"
+
+  validation {
+    condition     = length(trimspace(var.role_name)) > 0 && length(var.role_name) <= 64
+    error_message = "role_name must be non-empty and no longer than 64 characters."
+  }
+}
+
+variable "managed_policy_arns" {
+  type        = map(string)
+  description = "Managed policy ARNs shared by the infrastructure and deploy-permissions modules."
+  default = {
+    readonly = "arn:aws:iam::123456789012:policy/contract-readonly"
+  }
+}
+
+variable "force_detach_policies" {
+  type        = bool
+  description = "Force-detach setting shared by the infrastructure and deploy-permissions modules."
+  default     = false
+}
+
+module "infrastructure" {
+  source = "../../../modules/internal/github-actions-aws-role"
+
+  role_name                = var.role_name
+  force_detach_policies    = var.force_detach_policies
+  github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+  github_repository        = "example-org/example-repo"
+  role_secret_name         = "AWS_CONTRACT_ROLE_ARN"
+  managed_policy_arns      = var.managed_policy_arns
+
+  trusted_workflows = [{
+    workflow_filename = "tests.yaml"
+    context = {
+      type  = "branch"
+      value = "main"
+    }
+  }]
+}
+
+module "deploy_permissions" {
+  source = "../../../deploy-permissions/internal/github-actions-aws-role"
+
+  role_name             = var.role_name
+  managed_policy_arns   = var.managed_policy_arns
+  force_detach_policies = var.force_detach_policies
+}
+
+output "permissions_plan" {
+  value = module.deploy_permissions.plan
+}
+
+output "permissions_create" {
+  value = module.deploy_permissions.create
+}
+
+output "permissions_update" {
+  value = module.deploy_permissions.update
+}
+
+output "permissions_destroy" {
+  value = module.deploy_permissions.destroy
+}
+
+output "permissions_all" {
+  value = module.deploy_permissions.all
+}

--- a/tests/contracts/internal-github-actions-aws-role/main.tftest.hcl
+++ b/tests/contracts/internal-github-actions-aws-role/main.tftest.hcl
@@ -1,0 +1,147 @@
+mock_provider "aws" {
+  alias = "mock"
+}
+
+mock_provider "github" {
+  alias = "mock"
+}
+
+override_data {
+  target = module.infrastructure.data.aws_iam_openid_connect_provider.github_by_arn
+  values = {
+    client_id_list = ["sts.amazonaws.com"]
+  }
+}
+
+override_resource {
+  target = module.infrastructure.aws_iam_role.github_actions
+  values = {
+    arn = "arn:aws:iam::123456789012:role/contract-test-role"
+  }
+}
+
+override_data {
+  target = module.deploy_permissions.data.aws_caller_identity.current
+  values = {
+    account_id = "123456789012"
+  }
+}
+
+override_data {
+  target = module.deploy_permissions.data.aws_partition.current
+  values = {
+    partition = "aws"
+  }
+}
+
+run "resource_and_permissions_contract" {
+  command = plan
+
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition     = module.infrastructure.role_name == var.role_name
+    error_message = "The infrastructure module should manage the configured role."
+  }
+
+  assert {
+    condition     = module.infrastructure.role_arn == "arn:aws:iam::123456789012:role/contract-test-role"
+    error_message = "The infrastructure module should expose the managed role ARN."
+  }
+
+  assert {
+    condition = alltrue([
+      for statement in jsondecode(output.permissions_all).Statement :
+      statement.Resource == ["arn:aws:iam::123456789012:role/${var.role_name}"]
+    ])
+    error_message = "Every IAM operation should target the exact configured role ARN."
+  }
+
+  assert {
+    condition = one([
+      for statement in jsondecode(output.permissions_all).Statement : statement
+      if statement.Sid == "GitHubActionsManagedPolicyAttach"
+    ]).Condition.ArnEquals["iam:PolicyARN"] == [var.managed_policy_arns["readonly"]]
+    error_message = "Managed policy attachment should be limited to the policy configured on the infrastructure module."
+  }
+
+  assert {
+    condition = (
+      contains(flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]), "iam:CreateRole") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]), "iam:DeleteRole") &&
+      contains(flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]), "iam:UpdateAssumeRolePolicy") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]), "iam:CreateRole") &&
+      contains(flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]), "iam:DeleteRole") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]), "iam:CreateRole")
+    )
+    error_message = "Create, update, and destroy policies should contain only their lifecycle mutations."
+  }
+
+  assert {
+    condition = (
+      length(distinct([for statement in jsondecode(output.permissions_all).Statement : statement.Sid])) == length(jsondecode(output.permissions_all).Statement) &&
+      length(setsubtract(
+        toset(concat(
+          flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]),
+        )),
+        toset(flatten([for statement in jsondecode(output.permissions_all).Statement : statement.Action])),
+      )) == 0 &&
+      length(setsubtract(
+        toset(flatten([for statement in jsondecode(output.permissions_all).Statement : statement.Action])),
+        toset(concat(
+          flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]),
+        )),
+      )) == 0
+    )
+    error_message = "The all policy should be the deduplicated union of create, update, and destroy permissions."
+  }
+}
+
+run "force_detach_contract" {
+  command = plan
+
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  variables {
+    force_detach_policies = true
+  }
+
+  assert {
+    condition = (
+      !can(one([
+        for statement in jsondecode(output.permissions_destroy).Statement : statement
+        if statement.Sid == "GitHubActionsManagedPolicyForceDetach"
+      ]).Condition)
+    )
+    error_message = "The infrastructure and deploy-permissions modules should enable force detach together."
+  }
+}
+
+run "reject_invalid_shared_role_name" {
+  command = plan
+
+  providers = {
+    aws    = aws.mock
+    github = github.mock
+  }
+
+  variables {
+    role_name = ""
+  }
+
+  expect_failures = [var.role_name]
+}

--- a/tests/contracts/internal-github-actions-aws-role/main.tftest.hcl
+++ b/tests/contracts/internal-github-actions-aws-role/main.tftest.hcl
@@ -122,12 +122,17 @@ run "force_detach_contract" {
 
   assert {
     condition = (
-      !can(one([
+      length([
         for statement in jsondecode(output.permissions_destroy).Statement : statement
         if statement.Sid == "GitHubActionsManagedPolicyForceDetach"
-      ]).Condition)
+      ]) == 1 &&
+      alltrue([
+        for statement in jsondecode(output.permissions_destroy).Statement :
+        !can(statement.Condition)
+        if statement.Sid == "GitHubActionsManagedPolicyForceDetach"
+      ])
     )
-    error_message = "The infrastructure and deploy-permissions modules should enable force detach together."
+    error_message = "Force detach should emit exactly one unrestricted managed-policy detach statement."
   }
 }
 

--- a/tests/contracts/internal-github-actions-aws-role/providers.tf
+++ b/tests/contracts/internal-github-actions-aws-role/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/tests/contracts/tfstate-aws-backend/main.tf
+++ b/tests/contracts/tfstate-aws-backend/main.tf
@@ -1,0 +1,37 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name shared by the infrastructure and deploy-permissions modules."
+  default     = "contract-test-tfstate"
+}
+
+module "infrastructure" {
+  source = "../../../modules/tfstate-aws-backend"
+
+  bucket_name = var.bucket_name
+}
+
+module "deploy_permissions" {
+  source = "../../../deploy-permissions/tfstate-aws-backend"
+
+  bucket_name = var.bucket_name
+}
+
+output "permissions_plan" {
+  value = module.deploy_permissions.plan
+}
+
+output "permissions_create" {
+  value = module.deploy_permissions.create
+}
+
+output "permissions_update" {
+  value = module.deploy_permissions.update
+}
+
+output "permissions_destroy" {
+  value = module.deploy_permissions.destroy
+}
+
+output "permissions_all" {
+  value = module.deploy_permissions.all
+}

--- a/tests/contracts/tfstate-aws-backend/main.tftest.hcl
+++ b/tests/contracts/tfstate-aws-backend/main.tftest.hcl
@@ -1,0 +1,62 @@
+mock_provider "aws" {
+  alias = "mock"
+}
+
+run "resource_and_permissions_contract" {
+  command = plan
+
+  providers = {
+    aws = aws.mock
+  }
+
+  plan_options {
+    refresh = false
+  }
+
+  assert {
+    condition = alltrue([
+      for statement in jsondecode(output.permissions_all).Statement :
+      statement.Resource == (
+        statement.Sid == "S3BucketDiscovery" ? ["*"] :
+        statement.Sid == "TfstateObjectCleanup" ? ["arn:aws:s3:::${var.bucket_name}/*"] :
+        ["arn:aws:s3:::${var.bucket_name}"]
+      )
+    ])
+    error_message = "S3 permissions should use the configured bucket and object ARNs; only discovery may target all resources."
+  }
+
+  assert {
+    condition = (
+      contains(flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]), "s3:CreateBucket") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]), "s3:DeleteBucket") &&
+      contains(flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]), "s3:PutBucketVersioning") &&
+      !contains(flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]), "s3:CreateBucket") &&
+      contains(flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]), "s3:DeleteObjectVersion") &&
+      contains(flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]), "s3:DeleteBucket")
+    )
+    error_message = "Create, update, and destroy policies should contain the required lifecycle-specific S3 mutations."
+  }
+
+  assert {
+    condition = (
+      length(distinct([for statement in jsondecode(output.permissions_all).Statement : statement.Sid])) == length(jsondecode(output.permissions_all).Statement) &&
+      length(setsubtract(
+        toset(concat(
+          flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]),
+        )),
+        toset(flatten([for statement in jsondecode(output.permissions_all).Statement : statement.Action])),
+      )) == 0 &&
+      length(setsubtract(
+        toset(flatten([for statement in jsondecode(output.permissions_all).Statement : statement.Action])),
+        toset(concat(
+          flatten([for statement in jsondecode(output.permissions_create).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_update).Statement : statement.Action]),
+          flatten([for statement in jsondecode(output.permissions_destroy).Statement : statement.Action]),
+        )),
+      )) == 0
+    )
+    error_message = "The all policy should be the deduplicated union of create, update, and destroy permissions."
+  }
+}

--- a/tests/contracts/tfstate-aws-backend/providers.tf
+++ b/tests/contracts/tfstate-aws-backend/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
This adds the `deploy-permissions` directory, which should mirror the structure of the `modules` directory. This includes permissions needed to manage deployment of the corresponding module (e.g., for creating roles to use for deployment from GitHub Actions). These should be split into `plan`, `create`, `update`, and `destroy` permissions, plus an `all` set that works for all.

Testing of existing permissions is mostly done through the `tests/contracts/`, which deploys (mock) infra and permissions, and validates that the mocked permissions are associated with the right infra resources. We'll add full deployment lifecycle tests in a future PR, but these are fast, credential-free tests to cover the basics.

Assisted-by: Codex.app:GPT-5.6-Sol-Medium